### PR TITLE
Update of test projects to .NET Core 3.1

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -37,22 +37,11 @@ jobs:
     - name: Run minver
       id: minver
       uses: thefringeninja/action-minver@2.0.0-preview1
-      
-    - name: Setup .NET Core 2.2
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 2.2.402
         
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
-        
-    - name: .NET Core SxS Workaround
-      run: |
-        SET DOTNET_22_ROOT=%DOTNET_ROOT:3.1.101=2.2.402%
-        xcopy /s /y /d %DOTNET_22_ROOT% %DOTNET_ROOT%
-      shell: cmd
       
     - name: Prepare CDE code signing certificate
       id: createCdeCert

--- a/src/Communication/CDMy.SAF.PubSub.Tests/CDMy.SAF.PubSub.Tests.csproj
+++ b/src/Communication/CDMy.SAF.PubSub.Tests/CDMy.SAF.PubSub.Tests.csproj
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MPL-2.0
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="C-DEngine" Version="5.108.0" />
+    <PackageReference Include="C-DEngine" Version="5.109.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Communication/SAF.Communication.Cde.TestHost/SAF.Communication.Cde.TestHost.csproj
+++ b/src/Communication/SAF.Communication.Cde.TestHost/SAF.Communication.Cde.TestHost.csproj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Communication/SAF.Communication.Cde.TestHost/SAF.Communication.Cde.TestHost.csproj
+++ b/src/Communication/SAF.Communication.Cde.TestHost/SAF.Communication.Cde.TestHost.csproj
@@ -14,8 +14,8 @@ SPDX-License-Identifier: MPL-2.0
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="C-DEngine" Version="5.108.0" />
-    <PackageReference Include="CDMyNMIHtml5RT" Version="5.108.0" />
+    <PackageReference Include="C-DEngine" Version="5.109.0" />
+    <PackageReference Include="CDMyNMIHtml5RT" Version="5.109.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/Communication/SAF.Communication.Cde/SAF.Communication.Cde.csproj
+++ b/src/Communication/SAF.Communication.Cde/SAF.Communication.Cde.csproj
@@ -20,6 +20,6 @@ SPDX-License-Identifier: MPL-2.0
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="C-DEngine" Version="5.108.0" />
+    <PackageReference Include="C-DEngine" Version="5.109.0" />
   </ItemGroup>
 </Project>

--- a/src/Communication/SAF.Communication.PubSub.Cde/SAF.Communication.PubSub.Cde.csproj
+++ b/src/Communication/SAF.Communication.PubSub.Cde/SAF.Communication.PubSub.Cde.csproj
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MPL-2.0
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="C-DEngine" Version="5.108.0" />
+    <PackageReference Include="C-DEngine" Version="5.109.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Hosting/CDMy.SmartApplicationFramework/CDMy.SmartApplicationFramework.csproj
+++ b/src/Hosting/CDMy.SmartApplicationFramework/CDMy.SmartApplicationFramework.csproj
@@ -20,7 +20,7 @@ SPDX-License-Identifier: MPL-2.0
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="C-DEngine" Version="5.108.0" />
+    <PackageReference Include="C-DEngine" Version="5.109.0" />
    </ItemGroup>
 
   <ItemGroup>

--- a/src/Hosting/SAF.Hosting.Cde.Tests/SAF.Hosting.Cde.Tests.csproj
+++ b/src/Hosting/SAF.Hosting.Cde.Tests/SAF.Hosting.Cde.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Hosting/SAF.Hosting.Cde/SAF.Hosting.Cde.csproj
+++ b/src/Hosting/SAF.Hosting.Cde/SAF.Hosting.Cde.csproj
@@ -20,7 +20,7 @@ SPDX-License-Identifier: MPL-2.0
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="C-DEngine" Version="5.108.0" />
+    <PackageReference Include="C-DEngine" Version="5.109.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />

--- a/src/Hosting/SAF.Hosting.Tests/SAF.Hosting.Tests.csproj
+++ b/src/Hosting/SAF.Hosting.Tests/SAF.Hosting.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Cde.Tests/SAF.Messaging.Cde.Tests.csproj
+++ b/src/Messaging/SAF.Messaging.Cde.Tests/SAF.Messaging.Cde.Tests.csproj
@@ -17,7 +17,7 @@ SPDX-License-Identifier: MPL-2.0
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="C-DEngine" Version="5.108.0" />
+    <PackageReference Include="C-DEngine" Version="5.109.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/src/Messaging/SAF.Messaging.Cde.Tests/SAF.Messaging.Cde.Tests.csproj
+++ b/src/Messaging/SAF.Messaging.Cde.Tests/SAF.Messaging.Cde.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Messaging/SAF.Messaging.InProcess.Tests/SAF.Messaging.InProcess.Tests.csproj
+++ b/src/Messaging/SAF.Messaging.InProcess.Tests/SAF.Messaging.InProcess.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Messaging/SAF.Messaging.LoadTest/SAF.Messaging.LoadTest.csproj
+++ b/src/Messaging/SAF.Messaging.LoadTest/SAF.Messaging.LoadTest.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Routing.Tests/SAF.Messaging.Routing.Tests.csproj
+++ b/src/Messaging/SAF.Messaging.Routing.Tests/SAF.Messaging.Routing.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Services/SAF.Services.SampleService1.Tests/SAF.Services.SampleService1.Tests.csproj
+++ b/src/Services/SAF.Services.SampleService1.Tests/SAF.Services.SampleService1.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Storage/SAF.Storage.LightDb.Test/SAF.Storage.LiteDb.Test.csproj
+++ b/src/Storage/SAF.Storage.LightDb.Test/SAF.Storage.LiteDb.Test.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/TestRunnerCde/TestRunnerCde.csproj
+++ b/src/TestRunnerCde/TestRunnerCde.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/TestRunnerCdeWithSafPlugin/TestRunnerCdeWithSafPlugin.csproj
+++ b/src/TestRunnerCdeWithSafPlugin/TestRunnerCdeWithSafPlugin.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/TestRunnerCdeWithSafPlugin/TestRunnerCdeWithSafPlugin.csproj
+++ b/src/TestRunnerCdeWithSafPlugin/TestRunnerCdeWithSafPlugin.csproj
@@ -28,8 +28,8 @@ SPDX-License-Identifier: MPL-2.0
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="C-DEngine" Version="5.108.0" />
-    <PackageReference Include="CDMyNMIHtml5RT" Version="5.108.0" />
+    <PackageReference Include="C-DEngine" Version="5.109.0" />
+    <PackageReference Include="CDMyNMIHtml5RT" Version="5.109.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/TestRunnerConsole/TestRunnerConsole.csproj
+++ b/src/TestRunnerConsole/TestRunnerConsole.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/TestRunnerMessageRouting/TestRunnerMessageRouting.csproj
+++ b/src/TestRunnerMessageRouting/TestRunnerMessageRouting.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/TestRunnerRedis/TestRunnerRedis.csproj
+++ b/src/TestRunnerRedis/TestRunnerRedis.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/TestSequenceRunner/TestSequenceRunner.csproj
+++ b/src/TestSequenceRunner/TestSequenceRunner.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Toolbox/SAF.Toolbox.Tests/SAF.Toolbox.Tests.csproj
+++ b/src/Toolbox/SAF.Toolbox.Tests/SAF.Toolbox.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 SPDX-FileCopyrightText: 2017-2020 TRUMPF Laser GmbH
 
 SPDX-License-Identifier: MPL-2.0
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Toolbox/SAF.Toolbox/SAF.Toolbox.csproj
+++ b/src/Toolbox/SAF.Toolbox/SAF.Toolbox.csproj
@@ -16,7 +16,7 @@ SPDX-License-Identifier: MPL-2.0
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="12.1.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Necessary as .NET Core 2.2 has been marked as EOL.