### PR TITLE
Extended diagnostic output for starting/stopping services

### DIFF
--- a/src/Hosting/SAF.Hosting/ServiceCollectionExtensions.cs
+++ b/src/Hosting/SAF.Hosting/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -54,11 +55,12 @@ namespace SAF.Hosting
             foreach(var assembly in results)
             {
                 var loadedAssembly = Assembly.LoadFrom(assembly);
-                logger.LogInformation("Loading assembly: {0}, Version: {1}", assembly, loadedAssembly.GetName().Version.ToString());
+                var versionInfo = FileVersionInfo.GetVersionInfo(loadedAssembly.Location);
+                logger.LogInformation($"Loading assembly: {assembly}, FileVersion: {versionInfo.FileVersion}, ProductVersion: {versionInfo.ProductVersion}, Version: {loadedAssembly.GetName().Version}");
 
                 var manifest = loadedAssembly.GetExportedTypes().SingleOrDefault(t => t.IsClass && typeof(IServiceAssemblyManifest).IsAssignableFrom(t));
 
-                if(manifest == default(Type))
+                if(manifest == default)
                 {
                     logger.LogError($"Assembly {loadedAssembly.FullName} skipped: a valid assembly should contain exactly one public manifest.");
                     continue;

--- a/src/Hosting/SAF.Hosting/ServiceHost.cs
+++ b/src/Hosting/SAF.Hosting/ServiceHost.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
@@ -48,20 +49,48 @@ namespace SAF.Hosting
 
         public void StartServices()
         {
-            foreach(var service in _services)
+            var stopWatch = new Stopwatch();
+            stopWatch.Start();
+
+            foreach (var service in _services)
             {
+                _log.LogDebug($"Starting service: {service.GetType().Name}");
+
+                var serviceStopWatch = new Stopwatch();
+                serviceStopWatch.Start();
+
                 service.Start();
-                _log.LogInformation($"Started service: {service.GetType().Name}");
+
+                serviceStopWatch.Stop();
+
+                _log.LogInformation($"Started service: {service.GetType().Name}, start-up took {serviceStopWatch.Elapsed.TotalMilliseconds * 1000000:N0} ns");
             }
+
+            stopWatch.Stop();
+            _log.LogInformation($"Starting all services took {stopWatch.Elapsed.TotalMilliseconds * 1000000:N0} ns");
         }
 
         public void Dispose()
         {
-            foreach(var service in _services)
+            var stopWatch = new Stopwatch();
+            stopWatch.Start();
+
+            foreach (var service in _services)
             {
+                _log.LogDebug($"Stopping service: {service.GetType().Name}");
+
+                var serviceStopWatch = new Stopwatch();
+                serviceStopWatch.Start();
+
                 service.Stop();
-                _log.LogInformation($"Stopped service: {service.GetType().Name}");
+
+                serviceStopWatch.Stop();
+
+                _log.LogInformation($"Stopped service: {service.GetType().Name}, shutdown took {serviceStopWatch.Elapsed.TotalMilliseconds * 1000000:N0} ns");
             }
+
+            stopWatch.Stop();
+            _log.LogInformation($"Stopping all services took {stopWatch.Elapsed.TotalMilliseconds * 1000000:N0} ns");
         }
 
         private ServiceHostEnvironment BuildServiceHostEnvironment()


### PR DESCRIPTION
Extended version information output of considered service assemblies.
Use Stopwatch to measure service start-up and shutdown times and output the measured times.