### PR TITLE
Turn off CDE certificate path verification by default

### DIFF
--- a/src/Messaging/SAF.Messaging.Cde/CdeApplication.cs
+++ b/src/Messaging/SAF.Messaging.Cde/CdeApplication.cs
@@ -102,8 +102,8 @@ namespace SAF.Messaging.Cde
         {
             if (string.IsNullOrWhiteSpace(cryptpLibConfig?.DllName)) return;
 
-            var error = TheBaseAssets.LoadCrypto(cryptpLibConfig.DllName, null, cryptpLibConfig.DontVerifyTrust, null,
-                true, cryptpLibConfig.DontVerifyIntegrity);
+            var error = TheBaseAssets.LoadCrypto(cryptpLibConfig.DllName, null, cryptpLibConfig.DontVerifyTrust, null, 
+                cryptpLibConfig.VerifyTrustPath, cryptpLibConfig.DontVerifyIntegrity);
             if(!string.IsNullOrWhiteSpace(error))
                 throw new InvalidOperationException($"Failed loading configured crypto DLL: '{error}'");
         }

--- a/src/Messaging/SAF.Messaging.Cde/CdeConfiguration.cs
+++ b/src/Messaging/SAF.Messaging.Cde/CdeConfiguration.cs
@@ -11,6 +11,7 @@ namespace SAF.Messaging.Cde
         public string DllName { get; set; }
         public bool DontVerifyTrust { get; set; }
         public bool DontVerifyIntegrity { get; set; }
+        public bool VerifyTrustPath { get; set; } = true;
     }
 
     public class CdeConfiguration


### PR DESCRIPTION
C-Labs changed the default crypto Lib loading behaviour with CDE version 5.109.0

We should reflect that change by allowing the user to override the variable as well. 

The main reason: The CDE will request the Windows Registry to update itself if the root certificate isn't valid. This can take up to 30s. This results in slow boot times, that can be mitigated if the user already knows that a root certificate check isn't necessary.