### PR TITLE
Set global storage area name in sqlite to match liteDb and redis

### DIFF
--- a/src/Storage/SAF.Storage.SqLite.Test/StorageTests.cs
+++ b/src/Storage/SAF.Storage.SqLite.Test/StorageTests.cs
@@ -207,7 +207,7 @@ namespace SAF.Storage.SqLite.Test
         {
             using var storage = new Storage(_connection);
 
-            Assert.Throws<NotSupportedException>(() => storage.RemoveArea("globals"));
+            Assert.Throws<NotSupportedException>(() => storage.RemoveArea("global"));
         }
 
         [Fact]

--- a/src/Storage/SAF.Storage.SqLite/Storage.cs
+++ b/src/Storage/SAF.Storage.SqLite/Storage.cs
@@ -14,7 +14,7 @@ namespace SAF.Storage.SqLite
         private readonly SQLiteConnection _connection;
         private readonly ReaderWriterLockSlim _syncDbAccess = new(LockRecursionPolicy.SupportsRecursion);
 
-        private const string GlobalStorageArea = "globals";
+        private const string GlobalStorageArea = "global";
         private const string BytesValue = "bytesValue";
         private const string StringValue = "stringValue";
 


### PR DESCRIPTION
The current sqlite name `globals` is different from liteDb and redis `globals`. 
