### PR TITLE
Use product instead of file version in CdeNodeInfo

### DIFF
--- a/src/Messaging/SAF.Messaging.Cde/Diagnostics/CdeNodeInfo.cs
+++ b/src/Messaging/SAF.Messaging.Cde/Diagnostics/CdeNodeInfo.cs
@@ -40,7 +40,7 @@ namespace SAF.Messaging.Cde.Diagnostics
             var info = new CdePluginInfo
             {
                 Name = plugInKey,
-                Version = fvi.FileVersion,
+                Version = fvi.ProductVersion,
                 BuildNumber = plugInType.Assembly.GetName().Version.ToString(),
                 BuildDate = System.IO.File.GetLastWriteTimeUtc(plugInType.Assembly.Location)
             };


### PR DESCRIPTION
The File version within the diagnostic service isn't accurate enough. Instead the product version should be used. 