### PR TITLE
.NET9 Upgrade

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.x'
+        dotnet-version: '9.x'
         cache: true
         cache-dependency-path: 'Directory.Packages.props'
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,25 +12,25 @@ SPDX-License-Identifier: MPL-2.0
     <PackageVersion Include="C-DEngine" Version="6.104.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="LiteDB" Version="5.0.21" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.8.16" />
     <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.119" />
-    <PackageVersion Include="System.IO.Abstractions" Version="19.2.91" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.IO.Abstractions" Version="21.1.3" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/src/Communication/SAF.Communication.Cde/SAF.Communication.Cde.csproj
+++ b/src/Communication/SAF.Communication.Cde/SAF.Communication.Cde.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) convenience layer for C-DEngine basic communication.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.Cde/SAF.Communication.Cde.csproj
+++ b/src/Communication/SAF.Communication.Cde/SAF.Communication.Cde.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) convenience layer for C-DEngine basic communication.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.Cde/SAF.Communication.Cde.csproj
+++ b/src/Communication/SAF.Communication.Cde/SAF.Communication.Cde.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) convenience layer for C-DEngine basic communication.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.PubSub.Cde.Tests/SAF.Communication.PubSub.Cde.Tests.csproj
+++ b/src/Communication/SAF.Communication.PubSub.Cde.Tests/SAF.Communication.PubSub.Cde.Tests.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Communication/SAF.Communication.PubSub.Cde.Tests/TestCommunicationPubSubCde.cs
+++ b/src/Communication/SAF.Communication.PubSub.Cde.Tests/TestCommunicationPubSubCde.cs
@@ -40,9 +40,11 @@ public class TestCommunicationPubSubCde
         CheckRegistry(rrlh, MessageToken.SubscribeTrigger);
         CheckRegistryShutdown(rrlh);
 
-        RegistrySubscriptionResponse rsr = new();
-        rsr.id = "id";
-        rsr.instanceId = "instanceID";
+        RegistrySubscriptionResponse rsr = new()
+        {
+            id = "id",
+            instanceId = "instanceID"
+        };
         TSM tsm = new(Engines.PubSub, MessageToken.SubscribeResponse, TheCommonUtils.SerializeObjectToJSONString<RegistrySubscriptionResponse>(rsr));
         TheProcessMessage tpm = new(tsm);
         rrlh.HandleMessage(tpm);
@@ -58,7 +60,7 @@ public class TestCommunicationPubSubCde
         CheckNoRegistry(rrlh, MessageToken.Unsubscribe);
     }
 
-    private void CheckRegistry(RemoteRegistryLifetimeHandler rrlh, string messageToken)
+    private static void CheckRegistry(RemoteRegistryLifetimeHandler rrlh, string messageToken)
     {
         TSM tsm = new(Engines.PubSub, messageToken, "{\"address\":\"\",\"instanceId\":\"fee034c582a34e18afc248b82932034d\",\"version\":\"3.0.0\"}");
         TheProcessMessage tpm = new(tsm);
@@ -67,7 +69,7 @@ public class TestCommunicationPubSubCde
         Assert.Equal(tsm, rrlh.Registries[0]);
     }
 
-    private void CheckNoRegistry(RemoteRegistryLifetimeHandler rrlh, string messageToken)
+    private static void CheckNoRegistry(RemoteRegistryLifetimeHandler rrlh, string messageToken)
     {
         TSM tsm = new(Engines.PubSub, messageToken);
         TheProcessMessage tpm = new(tsm);
@@ -75,7 +77,7 @@ public class TestCommunicationPubSubCde
         Assert.Empty(rrlh.Registries);
     }
 
-    private void CheckRegistryShutdown(RemoteRegistryLifetimeHandler rrlh)
+    private static void CheckRegistryShutdown(RemoteRegistryLifetimeHandler rrlh)
     {
         TSM tsm = new(Engines.PubSub, MessageToken.RegistryShutdown);
         TheProcessMessage tpm = new(tsm);
@@ -88,10 +90,11 @@ public class TestCommunicationPubSubCde
     public void RunRemoteSubscriber()
     {
         TSM tsm = new(Engines.PubSub, MessageToken.SubscribeRequest);
-        List<string> lstPattern = new();
-        lstPattern.Add("pattern");
-        RegistrySubscriptionRequest rsr = new();
-        rsr.isRegistry = false;
+        List<string> lstPattern = ["pattern"];
+        RegistrySubscriptionRequest rsr = new()
+        {
+            isRegistry = false
+        };
         RemoteSubscriber resu = new(tsm, lstPattern, rsr);
         Assert.Equal(tsm, resu.Tsm);
         Assert.True(resu.IsAlive);
@@ -101,9 +104,9 @@ public class TestCommunicationPubSubCde
         rsr.version = PubSubVersion.Latest;
         Assert.Equal(PubSubVersion.Latest, resu.Version);
         Assert.True(resu.HasPatterns);
-        resu.RemovePatterns(new List<string> { "pattern" });
+        resu.RemovePatterns(["pattern"]);
         Assert.False(resu.HasPatterns);
-        resu.AddPatterns(new List<string> { "patt*" });
+        resu.AddPatterns(["patt*"]);
         Assert.True(resu.HasPatterns);
         Assert.True(resu.IsMatch("pattern"));
         Assert.False(resu.IsMatch("patern"));
@@ -144,7 +147,7 @@ public class TestCommunicationPubSubCde
         CheckBroadcast(subscriptionRegistry, RoutingOptions.Local, guid.ToString());
     }
 
-    private void CheckBroadcast(ISubscriptionRegistry subscriptionRegistry,
+    private static void CheckBroadcast(ISubscriptionRegistry subscriptionRegistry,
         RoutingOptions routingOptions = RoutingOptions.All,
         string guidString = "00000000-0000-0000-0000-000000000000")
     {
@@ -182,7 +185,7 @@ public class TestCommunicationPubSubCde
     }
 
     [Fact]
-    public async void RunSubscriptionRegistryWithSubstitute()
+    public async Task RunSubscriptionRegistryWithSubstitute()
     {
         var comLineSubscriptionRegistry = Substitute.For<ComLine>();
         comLineSubscriptionRegistry.Address.Returns("NOT RUNNING");
@@ -208,7 +211,7 @@ public class TestCommunicationPubSubCde
             Arg.Is<TSM>(t => t.TXT == MessageToken.SubscribeTrigger && t.PLS.Equals(registryIdent)));
         comLineSubscriptionRegistry.ClearReceivedCalls();
 
-        var tpmRegistry = this.CheckSubscribe(comLineSubscriptionRegistry);
+        var tpmRegistry = CheckSubscribe(comLineSubscriptionRegistry);
 
         // Send a subcribe alive request with registryIdentity and receive no registry alive request.
         tsm = new(Engines.PubSub, MessageToken.SubscriberAlive, registryIdent);
@@ -252,7 +255,7 @@ public class TestCommunicationPubSubCde
         comLineSubscriptionRegistry.DidNotReceive<ComLine>().AnswerToSender(Arg.Any<TSM>(), Arg.Any<TSM>());
     }
 
-    private TheProcessMessage CheckSubscribe(ComLine comLineSubscriptionRegistry)
+    private static TheProcessMessage CheckSubscribe(ComLine comLineSubscriptionRegistry)
     {
         // Send a subscribe request and receive a subscribe response with the given GUID
         // and the latest version (use this subscription in the next step to publish a message).
@@ -260,7 +263,7 @@ public class TestCommunicationPubSubCde
         RegistrySubscriptionRequest rsr = new()
         {
             id = guid.ToString("N"),
-            topics = new string[] { "topic" },
+            topics = ["topic"],
             isRegistry = true,
             version = PubSubVersion.Latest
         };
@@ -275,7 +278,7 @@ public class TestCommunicationPubSubCde
         return tpm;
     }
 
-    private TheProcessMessage CheckPublish(ComLine comLineSubscriptionRegistry)
+    private static TheProcessMessage CheckPublish(ComLine comLineSubscriptionRegistry)
     {
         // Sende a publish request and receive a publish request with the given
         // topic and payload.

--- a/src/Communication/SAF.Communication.PubSub.Cde/SAF.Communication.PubSub.Cde.csproj
+++ b/src/Communication/SAF.Communication.PubSub.Cde/SAF.Communication.PubSub.Cde.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) pub/sub communication extensions for C-DEngine.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.PubSub.Cde/SAF.Communication.PubSub.Cde.csproj
+++ b/src/Communication/SAF.Communication.PubSub.Cde/SAF.Communication.PubSub.Cde.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) pub/sub communication extensions for C-DEngine.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.PubSub.Cde/SAF.Communication.PubSub.Cde.csproj
+++ b/src/Communication/SAF.Communication.PubSub.Cde/SAF.Communication.PubSub.Cde.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) pub/sub communication extensions for C-DEngine.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.PubSub.Interfaces/SAF.Communication.PubSub.Interfaces.csproj
+++ b/src/Communication/SAF.Communication.PubSub.Interfaces/SAF.Communication.PubSub.Interfaces.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) Pub/Sub communication abstractions.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.PubSub.Interfaces/SAF.Communication.PubSub.Interfaces.csproj
+++ b/src/Communication/SAF.Communication.PubSub.Interfaces/SAF.Communication.PubSub.Interfaces.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) Pub/Sub communication abstractions.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.PubSub.Interfaces/SAF.Communication.PubSub.Interfaces.csproj
+++ b/src/Communication/SAF.Communication.PubSub.Interfaces/SAF.Communication.PubSub.Interfaces.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) Pub/Sub communication abstractions.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.PubSub.Tests/SAF.Communication.PubSub.Tests.csproj
+++ b/src/Communication/SAF.Communication.PubSub.Tests/SAF.Communication.PubSub.Tests.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Communication/SAF.Communication.PubSub/SAF.Communication.PubSub.csproj
+++ b/src/Communication/SAF.Communication.PubSub/SAF.Communication.PubSub.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) pub/sub communication basics.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.PubSub/SAF.Communication.PubSub.csproj
+++ b/src/Communication/SAF.Communication.PubSub/SAF.Communication.PubSub.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) pub/sub communication basics.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.PubSub/SAF.Communication.PubSub.csproj
+++ b/src/Communication/SAF.Communication.PubSub/SAF.Communication.PubSub.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) pub/sub communication basics.</Description>
   </PropertyGroup>
 

--- a/src/Hosting/SAF.Hosting.TestServices/SAF.Hosting.TestServices.csproj
+++ b/src/Hosting/SAF.Hosting.TestServices/SAF.Hosting.TestServices.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Hosting/SAF.Hosting.TestServices/SAF.Hosting.TestServices.csproj
+++ b/src/Hosting/SAF.Hosting.TestServices/SAF.Hosting.TestServices.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Hosting/SAF.Hosting.TestServices/SAF.Hosting.TestServices.csproj
+++ b/src/Hosting/SAF.Hosting.TestServices/SAF.Hosting.TestServices.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Hosting/SAF.Hosting.Tests/SAF.Hosting.Tests.csproj
+++ b/src/Hosting/SAF.Hosting.Tests/SAF.Hosting.Tests.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Hosting/SAF.Hosting/SAF.Hosting.csproj
+++ b/src/Hosting/SAF.Hosting/SAF.Hosting.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Hosting and startup infrastructures for Smart Application Framework (SAF) based applications.</Description>
   </PropertyGroup>
 

--- a/src/Hosting/SAF.Hosting/SAF.Hosting.csproj
+++ b/src/Hosting/SAF.Hosting/SAF.Hosting.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Hosting and startup infrastructures for Smart Application Framework (SAF) based applications.</Description>
   </PropertyGroup>
 

--- a/src/Hosting/SAF.Hosting/SAF.Hosting.csproj
+++ b/src/Hosting/SAF.Hosting/SAF.Hosting.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Hosting and startup infrastructures for Smart Application Framework (SAF) based applications.</Description>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Cde.Tests/SAF.Messaging.Cde.Tests.csproj
+++ b/src/Messaging/SAF.Messaging.Cde.Tests/SAF.Messaging.Cde.Tests.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Messaging/SAF.Messaging.Cde/SAF.Messaging.Cde.csproj
+++ b/src/Messaging/SAF.Messaging.Cde/SAF.Messaging.Cde.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) messaging infrastructure for C-DEngine based communication.</Description>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Cde/SAF.Messaging.Cde.csproj
+++ b/src/Messaging/SAF.Messaging.Cde/SAF.Messaging.Cde.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) messaging infrastructure for C-DEngine based communication.</Description>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Cde/SAF.Messaging.Cde.csproj
+++ b/src/Messaging/SAF.Messaging.Cde/SAF.Messaging.Cde.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) messaging infrastructure for C-DEngine based communication.</Description>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.InProcess.Tests/SAF.Messaging.InProcess.Tests.csproj
+++ b/src/Messaging/SAF.Messaging.InProcess.Tests/SAF.Messaging.InProcess.Tests.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Messaging/SAF.Messaging.InProcess/SAF.Messaging.InProcess.csproj
+++ b/src/Messaging/SAF.Messaging.InProcess/SAF.Messaging.InProcess.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) messaging infrastructure for in-process communication.</Description>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Messaging/SAF.Messaging.InProcess/SAF.Messaging.InProcess.csproj
+++ b/src/Messaging/SAF.Messaging.InProcess/SAF.Messaging.InProcess.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) messaging infrastructure for in-process communication.</Description>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Messaging/SAF.Messaging.InProcess/SAF.Messaging.InProcess.csproj
+++ b/src/Messaging/SAF.Messaging.InProcess/SAF.Messaging.InProcess.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) messaging infrastructure for in-process communication.</Description>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Messaging/SAF.Messaging.LoadTest/SAF.Messaging.LoadTest.csproj
+++ b/src/Messaging/SAF.Messaging.LoadTest/SAF.Messaging.LoadTest.csproj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Redis.Tests/SAF.Messaging.Redis.Tests.csproj
+++ b/src/Messaging/SAF.Messaging.Redis.Tests/SAF.Messaging.Redis.Tests.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Messaging/SAF.Messaging.Redis/SAF.Messaging.Redis.csproj
+++ b/src/Messaging/SAF.Messaging.Redis/SAF.Messaging.Redis.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) messaging infrastructure for Redis based communication.</Description>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Redis/SAF.Messaging.Redis.csproj
+++ b/src/Messaging/SAF.Messaging.Redis/SAF.Messaging.Redis.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) messaging infrastructure for Redis based communication.</Description>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Redis/SAF.Messaging.Redis.csproj
+++ b/src/Messaging/SAF.Messaging.Redis/SAF.Messaging.Redis.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) messaging infrastructure for Redis based communication.</Description>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Routing.Tests/SAF.Messaging.Routing.Tests.csproj
+++ b/src/Messaging/SAF.Messaging.Routing.Tests/SAF.Messaging.Routing.Tests.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Routing/SAF.Messaging.Routing.csproj
+++ b/src/Messaging/SAF.Messaging.Routing/SAF.Messaging.Routing.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) messaging infrastructure to allow message routing between different messaging systems.</Description>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Routing/SAF.Messaging.Routing.csproj
+++ b/src/Messaging/SAF.Messaging.Routing/SAF.Messaging.Routing.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) messaging infrastructure to allow message routing between different messaging systems.</Description>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Routing/SAF.Messaging.Routing.csproj
+++ b/src/Messaging/SAF.Messaging.Routing/SAF.Messaging.Routing.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) messaging infrastructure to allow message routing between different messaging systems.</Description>
   </PropertyGroup>
 

--- a/src/SAF.Common/SAF.Common.csproj
+++ b/src/SAF.Common/SAF.Common.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Common interface and type definitions for the Smart Application Framework (SAF).</Description>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SAF.Common/SAF.Common.csproj
+++ b/src/SAF.Common/SAF.Common.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Common interface and type definitions for the Smart Application Framework (SAF).</Description>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/SAF.Common/SAF.Common.csproj
+++ b/src/SAF.Common/SAF.Common.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Common interface and type definitions for the Smart Application Framework (SAF).</Description>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Services/SAF.Services.SampleService1.Tests/SAF.Services.SampleService1.Tests.csproj
+++ b/src/Services/SAF.Services.SampleService1.Tests/SAF.Services.SampleService1.Tests.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Services/SAF.Services.SampleService1/SAF.Services.SampleService1.csproj
+++ b/src/Services/SAF.Services.SampleService1/SAF.Services.SampleService1.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Services/SAF.Services.SampleService1/SAF.Services.SampleService1.csproj
+++ b/src/Services/SAF.Services.SampleService1/SAF.Services.SampleService1.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Services/SAF.Services.SampleService1/SAF.Services.SampleService1.csproj
+++ b/src/Services/SAF.Services.SampleService1/SAF.Services.SampleService1.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Services/SAF.Services.SampleService2/SAF.Services.SampleService2.csproj
+++ b/src/Services/SAF.Services.SampleService2/SAF.Services.SampleService2.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Services/SAF.Services.SampleService2/SAF.Services.SampleService2.csproj
+++ b/src/Services/SAF.Services.SampleService2/SAF.Services.SampleService2.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Services/SAF.Services.SampleService2/SAF.Services.SampleService2.csproj
+++ b/src/Services/SAF.Services.SampleService2/SAF.Services.SampleService2.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Storage/SAF.Storage.LightDb.Test/SAF.Storage.LiteDb.Test.csproj
+++ b/src/Storage/SAF.Storage.LightDb.Test/SAF.Storage.LiteDb.Test.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Storage/SAF.Storage.LightDb/SAF.Storage.LiteDb.csproj
+++ b/src/Storage/SAF.Storage.LightDb/SAF.Storage.LiteDb.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) LiteDb based storage infrastructure.</Description>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Storage/SAF.Storage.LightDb/SAF.Storage.LiteDb.csproj
+++ b/src/Storage/SAF.Storage.LightDb/SAF.Storage.LiteDb.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) LiteDb based storage infrastructure.</Description>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Storage/SAF.Storage.LightDb/SAF.Storage.LiteDb.csproj
+++ b/src/Storage/SAF.Storage.LightDb/SAF.Storage.LiteDb.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) LiteDb based storage infrastructure.</Description>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Storage/SAF.Storage.SqLite.Test/SAF.Storage.SqLite.Test.csproj
+++ b/src/Storage/SAF.Storage.SqLite.Test/SAF.Storage.SqLite.Test.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Storage/SAF.Storage.SqLite/SAF.Storage.SqLite.csproj
+++ b/src/Storage/SAF.Storage.SqLite/SAF.Storage.SqLite.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) SQLite based storage infrastructure.</Description>
   </PropertyGroup>
 

--- a/src/Storage/SAF.Storage.SqLite/SAF.Storage.SqLite.csproj
+++ b/src/Storage/SAF.Storage.SqLite/SAF.Storage.SqLite.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) SQLite based storage infrastructure.</Description>
   </PropertyGroup>
 

--- a/src/Storage/SAF.Storage.SqLite/SAF.Storage.SqLite.csproj
+++ b/src/Storage/SAF.Storage.SqLite/SAF.Storage.SqLite.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) SQLite based storage infrastructure.</Description>
   </PropertyGroup>
 

--- a/src/TestRunnerCde/TestRunnerCde.csproj
+++ b/src/TestRunnerCde/TestRunnerCde.csproj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TestRunnerCdeService1/TestRunnerCdeService1.csproj
+++ b/src/TestRunnerCdeService1/TestRunnerCdeService1.csproj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	  <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TestRunnerCdeService2/TestRunnerCdeService2.csproj
+++ b/src/TestRunnerCdeService2/TestRunnerCdeService2.csproj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	  <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TestRunnerConsole/TestRunnerConsole.csproj
+++ b/src/TestRunnerConsole/TestRunnerConsole.csproj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TestRunnerConsole/appsettings.json
+++ b/src/TestRunnerConsole/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "ServiceHost": {
-    "SearchPath": "../../../../Services/**/bin/Debug/netstandard2.1/SAF.Services.*.dll"
+    "SearchPath": "|../../../../Services/SAF.Services.SampleService1.Tests/**/*;../../../../Services/**/bin/Debug/net9.0/SAF.Services.*.dll"
   },
   "Logging": {
     "Console": {

--- a/src/TestRunnerMessageRouting/TestRunnerMessageRouting.csproj
+++ b/src/TestRunnerMessageRouting/TestRunnerMessageRouting.csproj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TestRunnerMessageRouting/appsettings.json
+++ b/src/TestRunnerMessageRouting/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "ServiceHost": {
-    "SearchPath": "../../../../Services/**/bin/Debug/netstandard2.1/SAF.Services.*.dll"
+    "SearchPath": "|../../../../Services/SAF.Services.SampleService1.Tests/**/*;../../../../Services/**/bin/Debug/net9.0/SAF.Services.*.dll"
   },
   "Logging": {
     "Console": {

--- a/src/TestRunnerRedis/TestRunnerRedis.csproj
+++ b/src/TestRunnerRedis/TestRunnerRedis.csproj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TestSequenceRunner/TestSequenceRunner.csproj
+++ b/src/TestSequenceRunner/TestSequenceRunner.csproj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/TestUtilities/TestUtilities.csproj
+++ b/src/TestUtilities/TestUtilities.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/TestUtilities/TestUtilities.csproj
+++ b/src/TestUtilities/TestUtilities.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/TestUtilities/TestUtilities.csproj
+++ b/src/TestUtilities/TestUtilities.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Toolbox/SAF.DevToolbox.Tests/SAF.DevToolbox.Tests.csproj
+++ b/src/Toolbox/SAF.DevToolbox.Tests/SAF.DevToolbox.Tests.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/Toolbox/SAF.DevToolbox/SAF.DevToolbox.csproj
+++ b/src/Toolbox/SAF.DevToolbox/SAF.DevToolbox.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) developer toolbox contains useful utilities to build test programs for SAF Plug-ins.</Description>
   </PropertyGroup>
 

--- a/src/Toolbox/SAF.DevToolbox/SAF.DevToolbox.csproj
+++ b/src/Toolbox/SAF.DevToolbox/SAF.DevToolbox.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) developer toolbox contains useful utilities to build test programs for SAF Plug-ins.</Description>
   </PropertyGroup>
 

--- a/src/Toolbox/SAF.DevToolbox/SAF.DevToolbox.csproj
+++ b/src/Toolbox/SAF.DevToolbox/SAF.DevToolbox.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) developer toolbox contains useful utilities to build test programs for SAF Plug-ins.</Description>
   </PropertyGroup>
 

--- a/src/Toolbox/SAF.Toolbox.Tests/SAF.Toolbox.Tests.csproj
+++ b/src/Toolbox/SAF.Toolbox.Tests/SAF.Toolbox.Tests.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Toolbox/SAF.Toolbox/Filetransfer/ChunkedFileHeader.cs
+++ b/src/Toolbox/SAF.Toolbox/Filetransfer/ChunkedFileHeader.cs
@@ -15,43 +15,43 @@ internal struct ChunkedFileHeader
     public static ChunkedFileHeader ReadFromMemoryMappedFile(MemoryMappedFile mmf, long maxChunks)
     {
         var header = new ChunkedFileHeader();
-        using (var headerAccessor = mmf.CreateViewStream(0, GetHeaderLengthInBytes(maxChunks)))
-        {
-            var buffer = new byte[sizeof(int)];
-            headerAccessor.Read(buffer, 0, buffer.Length);
-            header.Version = BitConverter.ToInt32(buffer, 0);
 
-            buffer = new byte[sizeof(long)];
-            headerAccessor.Read(buffer, 0, buffer.Length);
-            header.MaxChunks = BitConverter.ToInt64(buffer, 0);
-            if (header.MaxChunks == 0) header.MaxChunks = maxChunks;
+        using var headerAccessor = mmf.CreateViewStream(0, GetHeaderLengthInBytes(maxChunks));
 
-            var chunksReceivedBytes = header.MaxChunks * sizeof(bool);
-            buffer = new byte[chunksReceivedBytes];
-            headerAccessor.Read(buffer, 0, buffer.Length);
+        var buffer = new byte[sizeof(int)];
+        _ = headerAccessor.Read(buffer, 0, buffer.Length);
+        header.Version = BitConverter.ToInt32(buffer, 0);
 
-            header.ChunksReceived = new bool[chunksReceivedBytes / sizeof(bool)];
-            Buffer.BlockCopy(buffer, 0, header.ChunksReceived, 0, header.ChunksReceived.Length);
-        }
+        buffer = new byte[sizeof(long)];
+        _ = headerAccessor.Read(buffer, 0, buffer.Length);
+        header.MaxChunks = BitConverter.ToInt64(buffer, 0);
+        if (header.MaxChunks == 0) header.MaxChunks = maxChunks;
+
+        var chunksReceivedBytes = header.MaxChunks * sizeof(bool);
+        buffer = new byte[chunksReceivedBytes];
+        _ = headerAccessor.Read(buffer, 0, buffer.Length);
+
+        header.ChunksReceived = new bool[chunksReceivedBytes / sizeof(bool)];
+        Buffer.BlockCopy(buffer, 0, header.ChunksReceived, 0, header.ChunksReceived.Length);
+
         return header;
     }
 
-    public void WriteToMemoryMappedFile(MemoryMappedFile mmf)
+    public readonly void WriteToMemoryMappedFile(MemoryMappedFile mmf)
     {
-        using (var headerAccessor = mmf.CreateViewStream(0, LengthInBytes))
-        {
-            var buffer = BitConverter.GetBytes(Version);
-            headerAccessor.Write(buffer, 0, buffer.Length);
+        using var headerAccessor = mmf.CreateViewStream(0, LengthInBytes);
 
-            buffer = BitConverter.GetBytes(MaxChunks);
-            headerAccessor.Write(buffer, 0, buffer.Length);
+        var buffer = BitConverter.GetBytes(Version);
+        headerAccessor.Write(buffer, 0, buffer.Length);
 
-            buffer = new byte[ChunksReceived.Length * sizeof(bool)];
-            Buffer.BlockCopy(ChunksReceived, 0, buffer, 0, buffer.Length);
-            headerAccessor.Write(buffer, 0, buffer.Length);
-        }
+        buffer = BitConverter.GetBytes(MaxChunks);
+        headerAccessor.Write(buffer, 0, buffer.Length);
+
+        buffer = new byte[ChunksReceived.Length * sizeof(bool)];
+        Buffer.BlockCopy(ChunksReceived, 0, buffer, 0, buffer.Length);
+        headerAccessor.Write(buffer, 0, buffer.Length);
     }
 
-    private long LengthInBytes => GetHeaderLengthInBytes(MaxChunks);
+    private readonly long LengthInBytes => GetHeaderLengthInBytes(MaxChunks);
     public static long GetHeaderLengthInBytes(long maxChunks) => sizeof(int) + sizeof(long) + maxChunks * sizeof(bool);
 }

--- a/src/Toolbox/SAF.Toolbox/SAF.Toolbox.csproj
+++ b/src/Toolbox/SAF.Toolbox/SAF.Toolbox.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) Toolbox Services.</Description>
     <EnableNullable>enable</EnableNullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Toolbox/SAF.Toolbox/SAF.Toolbox.csproj
+++ b/src/Toolbox/SAF.Toolbox/SAF.Toolbox.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) Toolbox Services.</Description>
     <EnableNullable>enable</EnableNullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Toolbox/SAF.Toolbox/SAF.Toolbox.csproj
+++ b/src/Toolbox/SAF.Toolbox/SAF.Toolbox.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Description>Smart Application Framework (SAF) Toolbox Services.</Description>
     <EnableNullable>enable</EnableNullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Utils/CdeLogSorter/CdeLogSorter.csproj
+++ b/src/Utils/CdeLogSorter/CdeLogSorter.csproj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
* Upgrade to .NET9
* Upgraded all dependencies to latest versions
* Removed .NET Standard 2.1, .NET6.0 und .NET7.0 as target frameworks