### PR TITLE
Synchronize subscription

### DIFF
--- a/src/Messaging/SAF.Messaging.NATS/Messaging.cs
+++ b/src/Messaging/SAF.Messaging.NATS/Messaging.cs
@@ -141,11 +141,14 @@ internal sealed class Messaging : INatsMessagingInfrastructure, IDisposable
     {
         try
         {
+            var isSynchronized = false;
             var subject = _routeTranslator.TranslateRoute(routeFilterPattern);
             var cts = new CancellationTokenSource();
             var subscriptionTask = Task.Run(async () =>
             {
-                await foreach (var msg in _natsClient.SubscribeAsync<string>(subject: subject, cancellationToken: cts.Token))
+                var subscription = _natsClient.SubscribeAsync<string>(subject: subject, cancellationToken: cts.Token);
+                isSynchronized = true;
+                await foreach (var msg in subscription)
                 {
                     try
                     {
@@ -163,6 +166,8 @@ internal sealed class Messaging : INatsMessagingInfrastructure, IDisposable
                     }
                 }
             }, cts.Token);
+
+            WaitUtils.WaitUntil(() => isSynchronized, cts.Token).Wait(cts.Token);
 
             var subscriptionId = Guid.NewGuid();
             _subscriptionManager.TryAdd(subscriptionId, (routeFilterPattern, cts, subscriptionTask));

--- a/src/Messaging/SAF.Messaging.NATS/Messaging.cs
+++ b/src/Messaging/SAF.Messaging.NATS/Messaging.cs
@@ -167,7 +167,7 @@ internal sealed class Messaging : INatsMessagingInfrastructure, IDisposable
                 }
             }, cts.Token);
 
-            WaitUtils.WaitUntil(() => isSynchronized, cts.Token).Wait(cts.Token);
+            WaitUtilities.WaitUntil(() => isSynchronized, cts.Token).Wait(cts.Token);
 
             var subscriptionId = Guid.NewGuid();
             _subscriptionManager.TryAdd(subscriptionId, (routeFilterPattern, cts, subscriptionTask));

--- a/src/Messaging/SAF.Messaging.NATS/Messaging.cs
+++ b/src/Messaging/SAF.Messaging.NATS/Messaging.cs
@@ -146,9 +146,9 @@ internal sealed class Messaging : INatsMessagingInfrastructure, IDisposable
             var cts = new CancellationTokenSource();
             var subscriptionTask = Task.Run(async () =>
             {
-                var subscription = _natsClient.SubscribeAsync<string>(subject: subject, cancellationToken: cts.Token);
+                var subscription = await _natsClient.Connection.SubscribeCoreAsync<string>(subject: subject, cancellationToken: cts.Token);
                 isSynchronized = true;
-                await foreach (var msg in subscription)
+                await foreach (var msg in subscription.Msgs.ReadAllAsync(cts.Token))
                 {
                     try
                     {

--- a/src/SAF.Common/WaitUtilities.cs
+++ b/src/SAF.Common/WaitUtilities.cs
@@ -1,4 +1,8 @@
-﻿namespace SAF.Common;
+﻿// SPDX-FileCopyrightText: 2017-2025 TRUMPF Laser GmbH
+//
+// SPDX-License-Identifier: MPL-2.0
+
+namespace SAF.Common;
 
 public static class WaitUtilities
 {

--- a/src/SAF.Common/WaitUtilities.cs
+++ b/src/SAF.Common/WaitUtilities.cs
@@ -1,6 +1,6 @@
 ﻿namespace SAF.Common;
 
-public static class WaitUtils
+public static class WaitUtilities
 {
     public static async Task WaitUntil(Func<bool> condition, CancellationToken cancellationToken = default, TimeSpan frequency = default, TimeSpan timeout = default)
     {

--- a/src/SAF.Common/WaitUtils.cs
+++ b/src/SAF.Common/WaitUtils.cs
@@ -1,0 +1,23 @@
+﻿namespace SAF.Common;
+
+public static class WaitUtils
+{
+    public static async Task WaitUntil(Func<bool> condition, CancellationToken cancellationToken = default, TimeSpan frequency = default, TimeSpan timeout = default)
+    {
+        const int DEFAULT_FREQUENCY_IN_MILLISECONDS = 25;
+        const int DEFAULT_TIMEOUT_IN_SECONDS = 30;
+
+        var currentFrequency = frequency == TimeSpan.Zero ? TimeSpan.FromMilliseconds(DEFAULT_FREQUENCY_IN_MILLISECONDS) : frequency;
+        var currentTimeout = timeout == TimeSpan.Zero ? TimeSpan.FromSeconds(DEFAULT_TIMEOUT_IN_SECONDS) : timeout;
+
+        var waitTask = Task.Run(async () =>
+        {
+            while (!condition()) await Task.Delay(currentFrequency, cancellationToken);
+        }, cancellationToken);
+
+        if (waitTask != await Task.WhenAny(waitTask, Task.Delay(currentTimeout, cancellationToken)))
+        {
+            throw new TimeoutException();
+        }
+    }
+}


### PR DESCRIPTION
Ensures that the system waits until a valid subscription has been created on the NATS server before returning the subscription ID.