### PR TITLE
Target .NET10 only

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,8 +32,8 @@ SPDX-License-Identifier: MPL-2.0
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.10.1" />
     <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.119" />
-    <PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.0.16" />
-    <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.16" />
+    <PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.0" />
+    <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.1.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="Xunit.Extensions.Logging" Version="1.1.0" />

--- a/src/Communication/SAF.Communication.Cde/SAF.Communication.Cde.csproj
+++ b/src/Communication/SAF.Communication.Cde/SAF.Communication.Cde.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Smart Application Framework (SAF) convenience layer for C-DEngine basic communication.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.PubSub.Cde/SAF.Communication.PubSub.Cde.csproj
+++ b/src/Communication/SAF.Communication.PubSub.Cde/SAF.Communication.PubSub.Cde.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Smart Application Framework (SAF) pub/sub communication extensions for C-DEngine.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.PubSub.Interfaces/SAF.Communication.PubSub.Interfaces.csproj
+++ b/src/Communication/SAF.Communication.PubSub.Interfaces/SAF.Communication.PubSub.Interfaces.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Smart Application Framework (SAF) Pub/Sub communication abstractions.</Description>
   </PropertyGroup>
 

--- a/src/Communication/SAF.Communication.PubSub/SAF.Communication.PubSub.csproj
+++ b/src/Communication/SAF.Communication.PubSub/SAF.Communication.PubSub.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Smart Application Framework (SAF) pub/sub communication basics.</Description>
   </PropertyGroup>
 

--- a/src/Hosting/SAF.Hosting.Contracts/SAF.Hosting.Contracts.csproj
+++ b/src/Hosting/SAF.Hosting.Contracts/SAF.Hosting.Contracts.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Hosting/SAF.Hosting.TestServices/SAF.Hosting.TestServices.csproj
+++ b/src/Hosting/SAF.Hosting.TestServices/SAF.Hosting.TestServices.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Hosting/SAF.Hosting/SAF.Hosting.csproj
+++ b/src/Hosting/SAF.Hosting/SAF.Hosting.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Hosting and startup infrastructures for Smart Application Framework (SAF) based applications.</Description>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Cde/SAF.Messaging.Cde.csproj
+++ b/src/Messaging/SAF.Messaging.Cde/SAF.Messaging.Cde.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Smart Application Framework (SAF) messaging infrastructure for C-DEngine based communication.</Description>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.InProcess/SAF.Messaging.InProcess.csproj
+++ b/src/Messaging/SAF.Messaging.InProcess/SAF.Messaging.InProcess.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Smart Application Framework (SAF) messaging infrastructure for in-process communication.</Description>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Messaging/SAF.Messaging.NATS/SAF.Messaging.NATS.csproj
+++ b/src/Messaging/SAF.Messaging.NATS/SAF.Messaging.NATS.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
         <Description>Smart Application Framework (SAF) messaging infrastructure for NATS based communication.</Description>
     </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Redis/SAF.Messaging.Redis.csproj
+++ b/src/Messaging/SAF.Messaging.Redis/SAF.Messaging.Redis.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Smart Application Framework (SAF) messaging infrastructure for Redis based communication.</Description>
   </PropertyGroup>
 

--- a/src/Messaging/SAF.Messaging.Routing/SAF.Messaging.Routing.csproj
+++ b/src/Messaging/SAF.Messaging.Routing/SAF.Messaging.Routing.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Smart Application Framework (SAF) messaging infrastructure to allow message routing between different messaging systems.</Description>
   </PropertyGroup>
 

--- a/src/SAF.Common/SAF.Common.csproj
+++ b/src/SAF.Common/SAF.Common.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Common interface and type definitions for the Smart Application Framework (SAF).</Description>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Services/SAF.Services.SampleService1/SAF.Services.SampleService1.csproj
+++ b/src/Services/SAF.Services.SampleService1/SAF.Services.SampleService1.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Services/SAF.Services.SampleService2/SAF.Services.SampleService2.csproj
+++ b/src/Services/SAF.Services.SampleService2/SAF.Services.SampleService2.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Storage/SAF.Storage.LightDb/SAF.Storage.LiteDb.csproj
+++ b/src/Storage/SAF.Storage.LightDb/SAF.Storage.LiteDb.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Smart Application Framework (SAF) LiteDb based storage infrastructure.</Description>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Storage/SAF.Storage.SqLite/SAF.Storage.SqLite.csproj
+++ b/src/Storage/SAF.Storage.SqLite/SAF.Storage.SqLite.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Smart Application Framework (SAF) SQLite based storage infrastructure.</Description>
   </PropertyGroup>
 

--- a/src/TestUtilities/TestUtilities.csproj
+++ b/src/TestUtilities/TestUtilities.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Toolbox/SAF.DevToolbox/SAF.DevToolbox.csproj
+++ b/src/Toolbox/SAF.DevToolbox/SAF.DevToolbox.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Smart Application Framework (SAF) developer toolbox contains useful utilities to build test programs for SAF Plug-ins.</Description>
   </PropertyGroup>
 

--- a/src/Toolbox/SAF.Toolbox/SAF.Toolbox.csproj
+++ b/src/Toolbox/SAF.Toolbox/SAF.Toolbox.csproj
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Smart Application Framework (SAF) Toolbox Services.</Description>
     <EnableNullable>enable</EnableNullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
There is no need for Multittargeting. To reduce maintenance effort only .NET10 will be targeted from now on.