### PR TITLE
Fix ObjectDisposedException on shutdown

### DIFF
--- a/src/Communication/SAF.Communication.PubSub.Cde.Tests/MessageProcessing/BroadcastMessageQueueTests.cs
+++ b/src/Communication/SAF.Communication.PubSub.Cde.Tests/MessageProcessing/BroadcastMessageQueueTests.cs
@@ -9,7 +9,6 @@ using SAF.Communication.PubSub.Cde.MessageProcessing;
 using SAF.Communication.PubSub.Interfaces;
 using SAF.Common;
 using Xunit;
-using Xunit.Abstractions;
 
 public class BroadcastMessageQueueTests
 {

--- a/src/Communication/SAF.Communication.PubSub.Tests/TestCommunicationPubSub.cs
+++ b/src/Communication/SAF.Communication.PubSub.Tests/TestCommunicationPubSub.cs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 namespace SAF.Communication.PubSub.Tests;
-using NSubstitute;
+
 using Common;
 using Interfaces;
 using Xunit;

--- a/src/Hosting/SAF.Hosting.Tests/ServiceInterfaceProxyFactoryTests.cs
+++ b/src/Hosting/SAF.Hosting.Tests/ServiceInterfaceProxyFactoryTests.cs
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2017-2025 TRUMPF Laser GmbH
+//
+// SPDX-License-Identifier: MPL-2.0
+
+namespace SAF.Hosting.Tests;
+
+using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using SAF.Hosting;
+using Xunit;
+
+public class ServiceInterfaceProxyFactoryTests
+{
+    public interface ITestService
+    {
+        int Add(int a, int b);
+        Task<int> AddAsync(int a, int b);
+        bool ABooleanProperty { get; set; }
+    }
+
+#pragma warning disable S3881 // "IDisposable" should be implemented correctly
+    // Disposable test service implementation
+    public class TestServiceDisposable : ITestService, IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+        
+        public int Add(int a, int b) => a + b;
+        public Task<int> AddAsync(int a, int b) => Task.FromResult(a + b);
+        public bool ABooleanProperty { get; set; }
+
+        public void Dispose() => IsDisposed = true;
+    }
+
+    public class TestServiceAsyncDisposable : ITestService, IAsyncDisposable
+    {
+        public bool IsDisposedAsync { get; private set; }
+        
+        public int Add(int a, int b) => a + b;
+        public Task<int> AddAsync(int a, int b) => Task.FromResult(a + b);
+        public bool ABooleanProperty { get; set; }
+
+        public ValueTask DisposeAsync()
+        {
+            IsDisposedAsync = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public class ThrowingService : ITestService, IDisposable
+    {
+        public int Add(int a, int b) => throw new InvalidOperationException("boom");
+        public Task<int> AddAsync(int a, int b) => throw new InvalidOperationException("boom-async");
+        
+        public bool ABooleanProperty
+        {
+            get => throw new InvalidOperationException("boom-property-get");
+            set => throw new InvalidOperationException("boom-property-set");
+        }
+
+        public void Dispose() {}
+    }
+#pragma warning restore S3881 // "IDisposable" should be implemented correctly
+
+    private class TestServiceNonDisposable : ITestService
+    {
+        public int Add(int a, int b) => a + b;
+        public Task<int> AddAsync(int a, int b) => Task.FromResult(a + b);
+        public bool ABooleanProperty { get; set; }
+    }
+
+    [Fact]
+    public void Create_ReturnsOriginal_WhenNotDisposable()
+    {
+        ITestService target = new TestServiceNonDisposable();
+
+        var result = ServiceInterfaceProxyFactory.Create(target);
+
+        Assert.Same(target, result);
+    }
+
+    [Fact]
+    public void Create_ReturnsProxy_DelegatesMethods()
+    {
+        ITestService target = Substitute.For<TestServiceDisposable>();
+
+        var result = ServiceInterfaceProxyFactory.Create(target);
+
+        Assert.NotSame(target, result);
+        Assert.Equal(5, result.Add(2, 3));
+        target.Received(1).Add(2, 3);
+    }
+
+    [Fact]
+    public void Create_ReturnsProxy_DelegatesProperties()
+    {
+        ITestService target = new TestServiceDisposable();
+
+        var result = ServiceInterfaceProxyFactory.Create(target);
+        
+        Assert.NotSame(target, result);
+
+        result.ABooleanProperty = true;
+        Assert.True(target.ABooleanProperty);
+        result.ABooleanProperty = false;
+        Assert.False(target.ABooleanProperty);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsProxy_DelegatesAsyncMethods()
+    {
+        ITestService target = new TestServiceAsyncDisposable();
+
+        var result = ServiceInterfaceProxyFactory.Create(target);
+
+        Assert.NotSame(target, result);
+        var sum = await result.AddAsync(4, 6);
+        Assert.Equal(10, sum);
+    }
+
+    [Fact]
+    public void Create_ThrowsArgumentException_WhenTIsNotInterface()
+    {
+        var target = new TestServiceDisposable();
+
+        var ex = Assert.Throws<ArgumentException>(() => ServiceInterfaceProxyFactory.Create(target));
+        Assert.Contains("must be an interface", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Proxy_UnwrapsInnerExceptions_Sync()
+    {
+        ITestService target = new ThrowingService();
+        var proxy = ServiceInterfaceProxyFactory.Create(target);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => proxy.Add(1, 2));
+        Assert.Equal("boom", ex.Message);
+    }
+
+    [Fact]
+    public async Task Proxy_UnwrapsInnerExceptions_Async()
+    {
+        ITestService target = new ThrowingService();
+        var proxy = ServiceInterfaceProxyFactory.Create(target);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await proxy.AddAsync(1, 2));
+        Assert.Equal("boom-async", ex.Message);
+    }
+
+    [Fact]
+    public void Proxy_UnwrapsInnerExceptions_FromPropertyGetter()
+    {
+        ITestService target = new ThrowingService();
+        var proxy = ServiceInterfaceProxyFactory.Create(target);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => proxy.ABooleanProperty);
+        Assert.Equal("boom-property-get", ex.Message);
+    }
+
+    [Fact]
+    public void Proxy_UnwrapsInnerExceptions_Proxy_UnwrapsInnerExceptions_FromPropertySetter()
+    {
+        ITestService target = new ThrowingService();
+        var proxy = ServiceInterfaceProxyFactory.Create(target);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => proxy.ABooleanProperty = true);
+        Assert.Equal("boom-property-set", ex.Message);
+    }
+}

--- a/src/Hosting/SAF.Hosting.Tests/ServiceMessageDispatcherTests.cs
+++ b/src/Hosting/SAF.Hosting.Tests/ServiceMessageDispatcherTests.cs
@@ -7,7 +7,6 @@ namespace SAF.Hosting.Tests;
 using Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.VisualBasic;
 using NSubstitute;
 using TestUtilities;
 using Xunit;

--- a/src/Hosting/SAF.Hosting/ServiceHost.cs
+++ b/src/Hosting/SAF.Hosting/ServiceHost.cs
@@ -217,17 +217,17 @@ internal class ServiceHost(
 
     private void RedirectCommonServices(IServiceCollection assemblyServices, ServiceHostContext context)
     {
-        assemblyServices.AddSingleton(_ => applicationServiceProvider.GetRequiredService<ILoggerFactory>());
-        assemblyServices.AddTransient(_ => applicationServiceProvider.GetRequiredService<ILogger>());
+        assemblyServices.AddSingleton(_ => ServiceInterfaceProxyFactory.Create(applicationServiceProvider.GetRequiredService<ILoggerFactory>()));
+        assemblyServices.AddTransient(_ => ServiceInterfaceProxyFactory.Create(applicationServiceProvider.GetRequiredService<ILogger>()));
         assemblyServices.AddTransient(typeof(ILogger<>), typeof(Logger<>));
 
-        assemblyServices.AddSingleton(_ => applicationServiceProvider.GetRequiredService<IServiceHostInfo>());
-        assemblyServices.AddSingleton(_ => context.Environment);
+        assemblyServices.AddSingleton(_ => ServiceInterfaceProxyFactory.Create(applicationServiceProvider.GetRequiredService<IServiceHostInfo>()));
+        assemblyServices.AddSingleton(_ => ServiceInterfaceProxyFactory.Create(context.Environment));
 
-        assemblyServices.AddSingleton(_ => applicationServiceProvider.GetRequiredService<IConfiguration>());
+        assemblyServices.AddSingleton(_ => ServiceInterfaceProxyFactory.Create(applicationServiceProvider.GetRequiredService<IConfiguration>()));
 
-        assemblyServices.AddSingleton(_ => applicationServiceProvider.GetRequiredService<IMessagingInfrastructure>());
-        assemblyServices.AddSingleton(_ => applicationServiceProvider.GetRequiredService<IStorageInfrastructure>());
+        assemblyServices.AddSingleton(_ => ServiceInterfaceProxyFactory.Create(applicationServiceProvider.GetRequiredService<IMessagingInfrastructure>()));
+        assemblyServices.AddSingleton(_ => ServiceInterfaceProxyFactory.Create(applicationServiceProvider.GetRequiredService<IStorageInfrastructure>()));
     }
 
     private void AddApplicationMessageHandlersToDispatcher()

--- a/src/Hosting/SAF.Hosting/ServiceInterfaceProxyFactory.cs
+++ b/src/Hosting/SAF.Hosting/ServiceInterfaceProxyFactory.cs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2017-2025 TRUMPF Laser GmbH
+//
+// SPDX-License-Identifier: MPL-2.0
+
+namespace SAF.Hosting;
+
+using System;
+using System.Reflection;
+
+internal static class ServiceInterfaceProxyFactory
+{
+    /// <summary>
+    /// Creates a proxy for the specified target object if it implements <see cref="IDisposable"/> or <see
+    /// cref="IAsyncDisposable"/>; otherwise, returns the target object directly.
+    /// </summary>
+    /// <remarks>If the target object does not implement <see cref="IDisposable"/> or <see
+    /// cref="IAsyncDisposable"/>, no proxy is created and the original object is returned. This method is typically
+    /// used to enable interception of disposal operations on service interfaces.</remarks>
+    /// <typeparam name="T">The interface type of the target object. Must be a reference type and an interface.</typeparam>
+    /// <param name="target">The target object to proxy. If the object implements <see cref="IDisposable"/> or <see
+    /// cref="IAsyncDisposable"/>, a proxy is created; otherwise, the object is returned as-is. Cannot be <see
+    /// langword="null"/>.</param>
+    /// <returns>A proxy instance of type <typeparamref name="T"/> if the target implements <see cref="IDisposable"/> or <see
+    /// cref="IAsyncDisposable"/>; otherwise, the original target object.</returns>
+    /// <exception cref="ArgumentException">Thrown if <typeparamref name="T"/> is not an interface type.</exception>
+    public static T Create<T>(T target) where T : class
+    {
+        if(target is not IDisposable && target is not IAsyncDisposable)
+        {
+            // No proxy needed if target does not implement IDisposable
+            return target;
+        }
+
+        ArgumentNullException.ThrowIfNull(target);
+        if (!typeof(T).IsInterface)
+            throw new ArgumentException($"Type '{typeof(T)}' must be an interface.", nameof(target));
+
+        var proxy = DispatchProxy.Create<T, ServiceInterfaceProxy<T>>();
+        var instance = proxy as ServiceInterfaceProxy<T>;
+        instance?.SetTarget(target);
+
+        return proxy;
+    }
+
+    /// <summary>
+    /// Generic delegating proxy that implements an interface <typeparamref name="T"/> and forwards all calls
+    /// to a provided target instance that actually implements the interface.
+    /// </summary>
+    /// <typeparam name="T">The interface type to implement. Must be an interface.</typeparam>
+#pragma warning disable S3260 // Non-derived "private" classes and records should be "sealed"
+    // Must not be sealed to work with DispatchProxy.
+    private class ServiceInterfaceProxy<T> : DispatchProxy where T : class
+#pragma warning restore S3260 // Non-derived "private" classes and records should be "sealed"
+    {
+        private T? _target;
+
+        public void SetTarget(T target)
+        {
+            ArgumentNullException.ThrowIfNull(target);
+            _target = target;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            ArgumentNullException.ThrowIfNull(targetMethod);
+            if (_target is null)
+            {
+                throw new InvalidOperationException("Proxy target not initialized.");
+            }
+
+            try
+            {
+                return targetMethod.Invoke(_target, args);
+            }
+            catch (TargetInvocationException tie)
+            {
+                // Unwrap the inner exception thrown by reflection
+                throw tie.InnerException ?? tie;
+            }
+        }
+    }
+}

--- a/src/Messaging/SAF.Messaging.Cde.Tests/TestMessagingCde.cs
+++ b/src/Messaging/SAF.Messaging.Cde.Tests/TestMessagingCde.cs
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 namespace SAF.Messaging.Cde.Tests;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Common;
 using SAF.Communication.Cde;
-using Communication.PubSub;
 using Communication.PubSub.Interfaces;
 using Xunit;
 

--- a/src/TestRunnerConsole/appsettings.json
+++ b/src/TestRunnerConsole/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "ServiceHost": {
-    "SearchPath": "|../../../../Services/SAF.Services.SampleService1.Tests/**/*;../../../../Services/**/bin/Debug/net9.0/SAF.Services.*.dll"
+    "SearchPath": "|../../../../Services/SAF.Services.SampleService1.Tests/**/*;../../../../Services/**/bin/Debug/net10.0/SAF.Services.*.dll"
   },
   "Logging": {
     "Console": {

--- a/src/TestRunnerMessageRouting/appsettings.json
+++ b/src/TestRunnerMessageRouting/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "ServiceHost": {
-    "SearchPath": "|../../../../Services/SAF.Services.SampleService1.Tests/**/*;../../../../Services/**/bin/Debug/net9.0/SAF.Services.*.dll"
+    "SearchPath": "|../../../../Services/SAF.Services.SampleService1.Tests/**/*;../../../../Services/**/bin/Debug/net10.0/SAF.Services.*.dll"
   },
   "Logging": {
     "Console": {

--- a/src/Toolbox/SAF.Toolbox.Tests/FileTransfer/FileTransferLockManagerTests.cs
+++ b/src/Toolbox/SAF.Toolbox.Tests/FileTransfer/FileTransferLockManagerTests.cs
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 using SAF.Toolbox.FileTransfer;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace SAF.Toolbox.Tests.FileTransfer;


### PR DESCRIPTION
When shutting down a SAF host some infrastructure services (like IStorageInfrastructure) will get disposed multiple times, because they get disposed from the plug-ins DI containers as well as in the host applications DI container. This may lead to ObjectDisposedExceptions for some of them.

This PR ensures that the common infrastructure services won't get disposed from the plug-in services DI containers anymore so that the services will be disposed only once.