### PR TITLE
Allow configruation of external configuration sources

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -9,10 +9,6 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  contents: read
-  pull-requests: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
@@ -20,6 +16,8 @@ concurrency:
 jobs:
   precheck_push_without_pr:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       should_run_build: ${{ steps.open_pr_check.outputs.should_run_build }}
     steps:
@@ -55,6 +53,9 @@ jobs:
     if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || needs.precheck_push_without_pr.outputs.should_run_build == 'true'
     needs: [precheck_push_without_pr]
     runs-on: windows-latest
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
     - name: Setup JDK

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -9,19 +9,51 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
-  # For pull_request events github.head_ref contains the source branch name (e.g. "feature/foo").
-  # For a plain push to that same branch, github.head_ref is empty and we fall back to github.ref
-  # which becomes "refs/heads/feature/foo". Both resolve to the same logical group by stripping
-  # the refs/heads/ prefix via the replace expression.
-  # Result: a push to a branch with an open PR lands in the same concurrency group as the PR build,
-  # so only the latest run survives and duplicate work is avoided.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
-  build_test_pack:
+  precheck_push_without_pr:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run_build: ${{ steps.open_pr_check.outputs.should_run_build }}
+    steps:
+      - name: Check for open PR from branch
+        id: open_pr_check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isBranchPush = context.eventName === 'push' && context.ref.startsWith('refs/heads/');
+            const isMainPush = context.ref === 'refs/heads/main';
 
+            if (!isBranchPush || isMainPush) {
+              core.setOutput('should_run_build', 'true');
+              return;
+            }
+
+            const branch = context.ref.replace('refs/heads/', '');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = `${owner}:${branch}`;
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head
+            });
+
+            const shouldRunBuild = pulls.length === 0;
+            core.setOutput('should_run_build', shouldRunBuild ? 'true' : 'false');
+
+  build_test_pack:
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || needs.precheck_push_without_pr.outputs.should_run_build == 'true'
+    needs: [precheck_push_without_pr]
     runs-on: windows-latest
 
     steps:

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -2,7 +2,9 @@
      them), and jekyll-theme-slate doesn't render Mermaid either. Diagrams appear graphical
      when viewing the raw .md on github.com (which has its own Mermaid support), but not on
      the built Pages site — so render them client-side here instead. -->
-<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10.9.8/dist/mermaid.min.js"
+        integrity="sha384-N3QqR/7q+xm3BGX+CBbNI8AUmRRqcsDzToy+0z1NLDI0QmTKW8zvwLvqulJgk3dP"
+        crossorigin="anonymous"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     // Structure varies by markdown converter: CommonMark emits a bare

--- a/docs/migration-10-to-11.md
+++ b/docs/migration-10-to-11.md
@@ -270,7 +270,7 @@ Configuration was typically read directly from `IConfiguration` injected from th
 
 ### After
 
-All plugins share a single plugin settings file, resolved from `{PluginSettingsRootPath}/{PluginSettingsFilePath}` (defaults: `.` and `./pluginsettings.json`) plus an optional `{file}.{EnvironmentName}.json` overlay. Each plugin reads its own top-level section. It is exposed as `context.PluginConfiguration`:
+All plugins share a single plugin settings file, resolved from `{PluginSettingsRootPath}/{PluginSettingsFilePath}` (defaults: `./config` and `./pluginsettings.json`) plus an optional `{file}.{EnvironmentName}.json` overlay. Each plugin reads its own top-level section. It is exposed as `context.PluginConfiguration`:
 
 ```csharp
 public void ConfigureServices(IPluginSystemHostContext context, IServiceCollection pluginServices)

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -343,7 +343,7 @@ All plugins share a single plugin settings file, exposed to each manifest as `co
 {PluginSettingsRootPath}/{PluginSettingsFilePath}
 ```
 
-with `PluginSettingsRootPath` defaulting to `.` and `PluginSettingsFilePath` defaulting to `./pluginsettings.json`. An optional environment-specific overlay named `{file}.{EnvironmentName}.json` (e.g. `pluginsettings.Development.json`) is layered on top if present. Both paths come from the `PluginSystem` configuration section.
+with `PluginSettingsRootPath` defaulting to `./config` and `PluginSettingsFilePath` defaulting to `./pluginsettings.json`. An optional environment-specific overlay named `{file}.{EnvironmentName}.json` (e.g. `pluginsettings.Development.json`) is layered on top if present. Both paths come from the `PluginSystem` configuration section.
 
 `PluginSystemOptions` stays a pure data object (paths/patterns only). To add further plugin configuration providers from outside (for example XML, INI, custom sources, or application-specific file names/extensions), use the host builder API:
 

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -357,7 +357,7 @@ var pluginSystemBuilder = builder.AddPluginSystem(options =>
 });
 
 pluginSystemBuilder.AddPluginConfigurationSource(config =>
-    config.AddXmlFile("./config/pluginsettings.myapp", optional: true, reloadOnChange: true));
+    config.AddXmlFile("config/pluginsettings.myapp", optional: true, reloadOnChange: true));
 
 pluginSystemBuilder.AddPluginConfigurationSource(config =>
     config.AddXmlFile(

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -350,37 +350,48 @@ with `PluginSettingsRootPath` defaulting to `./config` and `PluginSettingsFilePa
 ```csharp
 var builder = Host.CreateApplicationBuilder(args);
 
-var pluginConfigRootPath = Path.Combine(AppContext.BaseDirectory, "config");
-
 var pluginSystemBuilder = builder.AddPluginSystem(options =>
 {
-    options.PluginSettingsRootPath = pluginConfigRootPath;
     options.PluginSettingsFilePath = "./pluginsettings.json";
 });
 
-pluginSystemBuilder.AddPluginConfigurationSource(config =>
-    config.AddXmlFile(Path.Combine(pluginConfigRootPath, "pluginsettings.myapp"), optional: true, reloadOnChange: true));
+pluginSystemBuilder.AddPluginConfigurationSource(source =>
+{
+    var extension = ".myapp";
+    var overlayFileName = $"{Path.GetFileNameWithoutExtension(source.SettingsFileName)}.{source.EnvironmentName}" +
+        Path.GetExtension(source.SettingsFileName);
 
-pluginSystemBuilder.AddPluginConfigurationSource(config =>
-    config.AddXmlFile(
-        Path.Combine(pluginConfigRootPath, $"pluginsettings.{builder.Environment.EnvironmentName}.myapp"),
-        optional: true,
-        reloadOnChange: true));
+    source.Builder.AddXmlFile(xml =>
+    {
+        xml.FileProvider = source.SettingsFileProvider;
+        xml.Path = Path.ChangeExtension(source.SettingsFileName, extension);
+        xml.Optional = true;
+        xml.ReloadOnChange = true;
+        xml.OnLoadException = source.OnLoadException;
+    });
+
+    source.Builder.AddXmlFile(xml =>
+    {
+        xml.FileProvider = source.SettingsFileProvider;
+        xml.Path = Path.ChangeExtension(overlayFileName, extension);
+        xml.Optional = true;
+        xml.ReloadOnChange = true;
+        xml.OnLoadException = source.OnLoadException;
+    });
+});
 ```
 
-Additional providers are appended after the default plugin JSON sources. Configuration precedence follows normal .NET rules (later providers override earlier ones).
+The callback receives a `PluginConfigurationSourceContext` with everything the built-in plugin settings
+pipeline already resolved: `SettingsFileProvider` (the `IFileProvider` scoped to the resolved settings
+directory — the same instance the default plugin JSON files use), `SettingsFileName` (e.g.
+`pluginsettings.json`), `EnvironmentName`, and `OnLoadException` (the shared handler that ignores a failed
+load and logs a warning instead of crashing host startup or silently wiping values on reload). Building
+sources through `source.SettingsFileProvider` keeps them rooted at the same directory as the default plugin
+JSON regardless of how `PluginSettingsRootPath` resolves — there is no separate path to keep in sync.
 
-> **`PluginSettingsRootPath` and custom source paths resolve independently.** The default plugin JSON is
-> located by resolving `PluginSettingsRootPath` (after `Environment.ExpandEnvironmentVariables`) against
-> `AppContext.BaseDirectory` — and `PluginSettingsRootPath` may itself be absolute (e.g.
-> `%ProgramData%/MyApp/config`). Custom sources added via `AddPluginConfigurationSource`, in contrast,
-> resolve through the configuration builder's file provider, which defaults to a
-> `PhysicalFileProvider(AppContext.BaseDirectory)` — it has no knowledge of `PluginSettingsRootPath` at all.
-> A relative path like `"./config"` used for both happens to resolve to the same place, but the two only
-> agree by coincidence — if `PluginSettingsRootPath` is changed to an absolute path elsewhere, the plugin
-> JSON and the custom sources silently start reading from different directories (worse yet, with
-> `optional: true` a miss stays silent). Building one absolute root and reusing it for both, as above, keeps
-> them in sync regardless of what `PluginSettingsRootPath` resolves to.
+The callback runs exactly once, during `IPluginSystemHostContext` construction; any exception it throws
+propagates into host startup. Additional providers are appended after the default plugin JSON sources.
+Configuration precedence follows normal .NET rules (later providers override earlier ones).
 
 Because the file is shared, plugins keep their settings under distinct top-level sections (the built-in messaging/storage plugins use `Messaging`, `Redis`, `Nats`, `LiteDb`, `SQLite`, `MessageRouting`).
 

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -345,6 +345,29 @@ All plugins share a single plugin settings file, exposed to each manifest as `co
 
 with `PluginSettingsRootPath` defaulting to `.` and `PluginSettingsFilePath` defaulting to `./pluginsettings.json`. An optional environment-specific overlay named `{file}.{EnvironmentName}.json` (e.g. `pluginsettings.Development.json`) is layered on top if present. Both paths come from the `PluginSystem` configuration section.
 
+`PluginSystemOptions` stays a pure data object (paths/patterns only). To add further plugin configuration providers from outside (for example XML, INI, custom sources, or application-specific file names/extensions), use the host builder API:
+
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
+
+var pluginSystemBuilder = builder.AddPluginSystem(options =>
+{
+    options.PluginSettingsRootPath = "./config";
+    options.PluginSettingsFilePath = "./pluginsettings.json";
+});
+
+pluginSystemBuilder.AddPluginConfigurationSource(config =>
+    config.AddXmlFile("./config/pluginsettings.myapp", optional: true, reloadOnChange: true));
+
+pluginSystemBuilder.AddPluginConfigurationSource(config =>
+    config.AddXmlFile(
+        $"./config/pluginsettings.{builder.Environment.EnvironmentName}.myapp",
+        optional: true,
+        reloadOnChange: true));
+```
+
+Additional providers are appended after the default plugin JSON sources. Configuration precedence follows normal .NET rules (later providers override earlier ones).
+
 Because the file is shared, plugins keep their settings under distinct top-level sections (the built-in messaging/storage plugins use `Messaging`, `Redis`, `Nats`, `LiteDb`, `SQLite`, `MessageRouting`).
 
 Access your section via `context.PluginConfiguration` in `ConfigureServices`:
@@ -369,6 +392,8 @@ Example `pluginsettings.json`:
 ```
 
 > A plugin may also fall back to host configuration (`context.HostConfiguration`) — the built-in plugins read their section from `PluginConfiguration` first and fall back to `HostConfiguration`. In the simplest setups you can point `PluginSettingsFilePath` at the host's `appsettings.json` and keep everything in one file.
+>
+> If you use `AddXmlFile(...)`, add the package `Microsoft.Extensions.Configuration.Xml` to the host project.
 
 ### Change tracking
 

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -350,23 +350,37 @@ with `PluginSettingsRootPath` defaulting to `.` and `PluginSettingsFilePath` def
 ```csharp
 var builder = Host.CreateApplicationBuilder(args);
 
+var pluginConfigRootPath = Path.Combine(AppContext.BaseDirectory, "config");
+
 var pluginSystemBuilder = builder.AddPluginSystem(options =>
 {
-    options.PluginSettingsRootPath = "./config";
+    options.PluginSettingsRootPath = pluginConfigRootPath;
     options.PluginSettingsFilePath = "./pluginsettings.json";
 });
 
 pluginSystemBuilder.AddPluginConfigurationSource(config =>
-    config.AddXmlFile("config/pluginsettings.myapp", optional: true, reloadOnChange: true));
+    config.AddXmlFile(Path.Combine(pluginConfigRootPath, "pluginsettings.myapp"), optional: true, reloadOnChange: true));
 
 pluginSystemBuilder.AddPluginConfigurationSource(config =>
     config.AddXmlFile(
-        $"./config/pluginsettings.{builder.Environment.EnvironmentName}.myapp",
+        Path.Combine(pluginConfigRootPath, $"pluginsettings.{builder.Environment.EnvironmentName}.myapp"),
         optional: true,
         reloadOnChange: true));
 ```
 
 Additional providers are appended after the default plugin JSON sources. Configuration precedence follows normal .NET rules (later providers override earlier ones).
+
+> **`PluginSettingsRootPath` and custom source paths resolve independently.** The default plugin JSON is
+> located by resolving `PluginSettingsRootPath` (after `Environment.ExpandEnvironmentVariables`) against
+> `AppContext.BaseDirectory` — and `PluginSettingsRootPath` may itself be absolute (e.g.
+> `%ProgramData%/MyApp/config`). Custom sources added via `AddPluginConfigurationSource`, in contrast,
+> resolve through the configuration builder's file provider, which defaults to a
+> `PhysicalFileProvider(AppContext.BaseDirectory)` — it has no knowledge of `PluginSettingsRootPath` at all.
+> A relative path like `"./config"` used for both happens to resolve to the same place, but the two only
+> agree by coincidence — if `PluginSettingsRootPath` is changed to an absolute path elsewhere, the plugin
+> JSON and the custom sources silently start reading from different directories (worse yet, with
+> `optional: true` a miss stays silent). Building one absolute root and reusing it for both, as above, keeps
+> them in sync regardless of what `PluginSettingsRootPath` resolves to.
 
 Because the file is shared, plugins keep their settings under distinct top-level sections (the built-in messaging/storage plugins use `Messaging`, `Redis`, `Nats`, `LiteDb`, `SQLite`, `MessageRouting`).
 

--- a/docs/saf-host.md
+++ b/docs/saf-host.md
@@ -132,7 +132,7 @@ builder.AddSafHost(pluginSystemOptions =>
 .ConfigurePluginSystem(ps =>
 {
     ps.AddPluginConfigurationSource(config =>
-        config.AddXmlFile("./config/pluginsettings.myapp", optional: true, reloadOnChange: true));
+        config.AddXmlFile("config/pluginsettings.myapp", optional: true, reloadOnChange: true));
 
     ps.AddPluginConfigurationSource(config =>
         config.AddXmlFile(

--- a/docs/saf-host.md
+++ b/docs/saf-host.md
@@ -131,14 +131,30 @@ builder.AddSafHost(pluginSystemOptions =>
 })
 .ConfigurePluginSystem(ps =>
 {
-    ps.AddPluginConfigurationSource(config =>
-        config.AddXmlFile("config/pluginsettings.myapp", optional: true, reloadOnChange: true));
+    ps.AddPluginConfigurationSource(source =>
+    {
+        var extension = ".myapp";
+        var overlayFileName = $"{Path.GetFileNameWithoutExtension(source.SettingsFileName)}.{source.EnvironmentName}" +
+            Path.GetExtension(source.SettingsFileName);
 
-    ps.AddPluginConfigurationSource(config =>
-        config.AddXmlFile(
-            $"./config/pluginsettings.{builder.Environment.EnvironmentName}.myapp",
-            optional: true,
-            reloadOnChange: true));
+        source.Builder.AddXmlFile(xml =>
+        {
+            xml.FileProvider = source.SettingsFileProvider;
+            xml.Path = Path.ChangeExtension(source.SettingsFileName, extension);
+            xml.Optional = true;
+            xml.ReloadOnChange = true;
+            xml.OnLoadException = source.OnLoadException;
+        });
+
+        source.Builder.AddXmlFile(xml =>
+        {
+            xml.FileProvider = source.SettingsFileProvider;
+            xml.Path = Path.ChangeExtension(overlayFileName, extension);
+            xml.Optional = true;
+            xml.ReloadOnChange = true;
+            xml.OnLoadException = source.OnLoadException;
+        });
+    });
 
     ps.AddPluginAssemblyFolderContainer(options =>
     {

--- a/docs/saf-host.md
+++ b/docs/saf-host.md
@@ -131,6 +131,15 @@ builder.AddSafHost(pluginSystemOptions =>
 })
 .ConfigurePluginSystem(ps =>
 {
+    ps.AddPluginConfigurationSource(config =>
+        config.AddXmlFile("./config/pluginsettings.myapp", optional: true, reloadOnChange: true));
+
+    ps.AddPluginConfigurationSource(config =>
+        config.AddXmlFile(
+            $"./config/pluginsettings.{builder.Environment.EnvironmentName}.myapp",
+            optional: true,
+            reloadOnChange: true));
+
     ps.AddPluginAssemblyFolderContainer(options =>
     {
         options.SearchRootPath = AppContext.BaseDirectory;
@@ -140,6 +149,8 @@ builder.AddSafHost(pluginSystemOptions =>
 })
 .AddHostDiagnostics();
 ```
+
+If you use `AddXmlFile(...)`, add the package `Microsoft.Extensions.Configuration.Xml` to the host project.
 
 ---
 

--- a/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/HostApplicationBuilderExtensionsTests.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/HostApplicationBuilderExtensionsTests.cs
@@ -128,7 +128,7 @@ public class HostApplicationBuilderExtensionsTests
                 ["Custom:Setting"] = "ValueFromOutside",
             }));
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
         var hostContext = serviceProvider.GetRequiredService<IPluginSystemHostContext>();
 
         // Assert

--- a/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/HostApplicationBuilderExtensionsTests.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/HostApplicationBuilderExtensionsTests.cs
@@ -122,8 +122,8 @@ public class HostApplicationBuilderExtensionsTests
         {
             options.PluginSettingsFilePath = string.Empty;
         });
-        pluginSystemHostBuilder.AddPluginConfigurationSource(configurationBuilder =>
-            configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        pluginSystemHostBuilder.AddPluginConfigurationSource(sourceContext =>
+            sourceContext.Builder.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["Custom:Setting"] = "ValueFromOutside",
             }));

--- a/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/HostApplicationBuilderExtensionsTests.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/HostApplicationBuilderExtensionsTests.cs
@@ -101,4 +101,37 @@ public class HostApplicationBuilderExtensionsTests
         Assert.Equal(environment, hostContext.Environment);
         Assert.Equal("./test-plugin-configs", environment.PluginSettingsRootPath);
     }
+
+    [Fact]
+    public void AddPluginSystem_AllowsAddingCustomPluginConfigurationSourcesFromOutside()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        var builder = Substitute.For<IHostApplicationBuilder>();
+        builder.Services.Returns(services);
+
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Is(nameof(PluginSystemHostContext)))
+            .Returns(NullLogger<PluginSystemHostContext>.Instance);
+        services.AddSingleton(loggerFactory);
+        services.AddTransient(typeof(ILogger<>), typeof(Logger<>));
+
+        // Act
+        var pluginSystemHostBuilder = builder.AddPluginSystem(options =>
+        {
+            options.PluginSettingsFilePath = string.Empty;
+        });
+        pluginSystemHostBuilder.AddPluginConfigurationSource(configurationBuilder =>
+            configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Custom:Setting"] = "ValueFromOutside",
+            }));
+
+        var serviceProvider = services.BuildServiceProvider();
+        var hostContext = serviceProvider.GetRequiredService<IPluginSystemHostContext>();
+
+        // Assert
+        Assert.Equal("ValueFromOutside", hostContext.PluginConfiguration["Custom:Setting"]);
+    }
 }

--- a/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostBuilderExtensionsTests.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostBuilderExtensionsTests.cs
@@ -5,8 +5,10 @@
 namespace SAF.PluginSystem.Hosting.Tests;
 
 using Contracts;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using System.Reflection;
 using System.IO.Abstractions;
@@ -69,5 +71,41 @@ public class PluginSystemHostBuilderExtensionsTests
 
         var searchOptions = service.GetType().GetProperty("SearchOptions", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(service) as PluginAssemblyFolderSearchOptions;
         Assert.Equal(configuredPath, searchOptions!.SearchRootPath);
+    }
+
+    [Fact]
+    public void AddPluginConfigurationSource_ThrowsIfHostBuilderEqualsNull()
+    {
+        IPluginSystemHostBuilder? hostBuilder = null;
+        Assert.Throws<ArgumentNullException>(() => hostBuilder!.AddPluginConfigurationSource(_ => { }));
+    }
+
+    [Fact]
+    public void AddPluginConfigurationSource_ThrowsIfConfigureSourceEqualsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => _hostBuilder.AddPluginConfigurationSource(null!));
+    }
+
+    [Fact]
+    public void AddPluginConfigurationSource_MultipleCalls_PreserveRegistrationOrder()
+    {
+        // Arrange
+        _hostBuilder.AddPluginConfigurationSource(builder =>
+            builder.AddInMemoryCollection(new Dictionary<string, string?> { ["Key"] = "First" }));
+        _hostBuilder.AddPluginConfigurationSource(builder =>
+            builder.AddInMemoryCollection(new Dictionary<string, string?> { ["Key"] = "Second" }));
+
+        // Act
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var configureSources = serviceProvider.GetRequiredService<IOptions<PluginConfigurationSourcesOptions>>().Value.ConfigureSources;
+
+        var configurationBuilder = new ConfigurationBuilder();
+        foreach (var configureSource in configureSources)
+            configureSource(configurationBuilder);
+        var configuration = configurationBuilder.Build();
+
+        // Assert — registration order is preserved, so the second call's provider overrides the first's.
+        Assert.Equal(2, configureSources.Count);
+        Assert.Equal("Second", configuration["Key"]);
     }
 }

--- a/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostBuilderExtensionsTests.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostBuilderExtensionsTests.cs
@@ -90,18 +90,26 @@ public class PluginSystemHostBuilderExtensionsTests
     public void AddPluginConfigurationSource_MultipleCalls_PreserveRegistrationOrder()
     {
         // Arrange
-        _hostBuilder.AddPluginConfigurationSource(builder =>
-            builder.AddInMemoryCollection(new Dictionary<string, string?> { ["Key"] = "First" }));
-        _hostBuilder.AddPluginConfigurationSource(builder =>
-            builder.AddInMemoryCollection(new Dictionary<string, string?> { ["Key"] = "Second" }));
+        _hostBuilder.AddPluginConfigurationSource(sourceContext =>
+            sourceContext.Builder.AddInMemoryCollection(new Dictionary<string, string?> { ["Key"] = "First" }));
+        _hostBuilder.AddPluginConfigurationSource(sourceContext =>
+            sourceContext.Builder.AddInMemoryCollection(new Dictionary<string, string?> { ["Key"] = "Second" }));
 
         // Act
         var serviceProvider = _serviceCollection.BuildServiceProvider();
         var configureSources = serviceProvider.GetRequiredService<IOptions<PluginConfigurationSourcesOptions>>().Value.ConfigureSources;
 
         var configurationBuilder = new ConfigurationBuilder();
+        var sourceContext = new PluginConfigurationSourceContext
+        {
+            Builder = configurationBuilder,
+            SettingsFileProvider = null,
+            EnvironmentName = "Test",
+            SettingsFileName = null,
+            OnLoadException = _ => { },
+        };
         foreach (var configureSource in configureSources)
-            configureSource(configurationBuilder);
+            configureSource(sourceContext);
         var configuration = configurationBuilder.Build();
 
         // Assert — registration order is preserved, so the second call's provider overrides the first's.

--- a/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostContextTests.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostContextTests.cs
@@ -5,6 +5,7 @@
 namespace SAF.PluginSystem.Hosting.Tests;
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Contracts;
@@ -426,5 +427,58 @@ public class PluginSystemHostContextTests
             new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources));
 
         Assert.Same(expectedException, thrownException);
+    }
+
+    [Fact]
+    public void BuildPluginConfiguration_MultipleCustomFileSources_ShareSingleDefaultFileProvider()
+    {
+        // Arrange
+        // Verifies that the shared PhysicalFileProvider seeded on the builder is reused by every custom
+        // FileConfigurationSource that does not set its own FileProvider, instead of each source creating
+        // its own PhysicalFileProvider(AppContext.BaseDirectory) via EnsureDefaults — which would leave
+        // N undisposed FileSystemWatcher handles after the context is disposed.
+        //
+        // This test also acts as a canary for future SDK changes to FileConfigurationSource.EnsureDefaults:
+        //   • Assert.NotNull  — detects if EnsureDefaults stops assigning FileProvider at all.
+        //   • Assert.Same     — detects if EnsureDefaults starts allocating a new provider per source.
+        //   • Root assertion  — detects if the shared provider is no longer rooted at AppContext.BaseDirectory.
+        // Any of these failing means the fix in BuildPluginConfiguration must be revisited.
+        var logger = Substitute.For<ILogger<PluginSystemHostContext>>();
+        var environment = Substitute.For<IPluginSystemHostEnvironment>();
+        var hostConfiguration = Substitute.For<IConfigurationManager>();
+        var options = new PluginSystemOptions { PluginSettingsFilePath = string.Empty };
+        var fileSystem = new RealFileSystem();
+
+        var configureSources = new List<Action<IConfigurationBuilder>>
+        {
+            builder => builder.AddJsonFile("nonexistent-a.json", optional: true, reloadOnChange: true),
+            builder => builder.AddJsonFile("nonexistent-b.json", optional: true, reloadOnChange: true),
+        };
+
+        // Act
+        using var context = new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources);
+
+        // Assert
+        var root = Assert.IsType<IConfigurationRoot>(context.PluginConfiguration, exactMatch: false);
+        var customProviders = root.Providers
+            .OfType<FileConfigurationProvider>()
+            .Select(p => p.Source.FileProvider)
+            .ToList();
+
+        Assert.Equal(2, customProviders.Count);
+
+        // Both providers must be non-null: if EnsureDefaults stops assigning FileProvider, Assert.Same(null, null)
+        // would pass silently and the canary would be blind.
+        Assert.All(customProviders, p => Assert.NotNull(p));
+
+        // Both sources must share the exact same instance, proving no per-source allocation occurred.
+        Assert.Same(customProviders[0], customProviders[1]);
+
+        // The shared instance must be the PhysicalFileProvider seeded on the builder, rooted at
+        // AppContext.BaseDirectory — the same root the SDK fallback would have used per source.
+        var physicalProvider = Assert.IsType<PhysicalFileProvider>(customProviders[0]);
+        Assert.Equal(
+            fileSystem.Path.GetFullPath(AppContext.BaseDirectory),
+            fileSystem.Path.GetFullPath(physicalProvider.Root));
     }
 }

--- a/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostContextTests.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostContextTests.cs
@@ -153,4 +153,58 @@ public class PluginSystemHostContextTests
             Assert.True(contextWithException.Ignore);
         }
     }
+
+    [Fact]
+    public void BuildPluginConfiguration_ShouldApplyCustomConfigurationSources()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<PluginSystemHostContext>>();
+        var environment = Substitute.For<IPluginSystemHostEnvironment>();
+        var hostConfiguration = Substitute.For<IConfigurationManager>();
+        var options = new PluginSystemOptions { PluginSettingsFilePath = string.Empty };
+        var configureSources = new List<Action<IConfigurationBuilder>>
+        {
+            builder =>
+            builder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Custom:Key"] = "CustomValue",
+            }),
+        };
+        // PluginSystemHostContext builds its configuration from settings files on disk, so a real file system is used.
+        var fileSystem = new RealFileSystem();
+
+        // Act
+        var context = new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources);
+
+        // Assert
+        Assert.Equal("CustomValue", context.PluginConfiguration["Custom:Key"]);
+    }
+
+    [Fact]
+    public void BuildPluginConfiguration_ShouldApplyCustomSourcesAfterDefaultSources()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<PluginSystemHostContext>>();
+        var environment = Substitute.For<IPluginSystemHostEnvironment>();
+        environment.EnvironmentName.Returns("Environment");
+        environment.PluginSettingsRootPath.Returns("./test-plugin-configs");
+        var hostConfiguration = Substitute.For<IConfigurationManager>();
+        var options = new PluginSystemOptions { PluginSettingsFilePath = "settings.json" };
+        var configureSources = new List<Action<IConfigurationBuilder>>
+        {
+            builder =>
+            builder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Key"] = "OverriddenByCustomSource",
+            }),
+        };
+        // PluginSystemHostContext builds its configuration from settings files on disk, so a real file system is used.
+        var fileSystem = new RealFileSystem();
+
+        // Act
+        var context = new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources);
+
+        // Assert
+        Assert.Equal("OverriddenByCustomSource", context.PluginConfiguration["Key"]);
+    }
 }

--- a/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostContextTests.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostContextTests.cs
@@ -202,7 +202,7 @@ public class PluginSystemHostContextTests
         var fileSystem = new RealFileSystem();
 
         // Act
-        var context = new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources);
+        using var context = new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources);
 
         // Assert
         Assert.Equal("OverriddenByCustomSource", context.PluginConfiguration["Key"]);

--- a/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostContextTests.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostContextTests.cs
@@ -156,6 +156,102 @@ public class PluginSystemHostContextTests
     }
 
     [Fact]
+    public void BuildPluginConfiguration_PassesSettingsFileProviderAndFileNameToCustomSources_WhenSettingsFileConfigured()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<PluginSystemHostContext>>();
+        var environment = Substitute.For<IPluginSystemHostEnvironment>();
+        environment.EnvironmentName.Returns("Environment");
+        environment.PluginSettingsRootPath.Returns("./test-plugin-configs");
+        var hostConfiguration = Substitute.For<IConfigurationManager>();
+        var options = new PluginSystemOptions { PluginSettingsFilePath = "settings.json" };
+        var fileSystem = new RealFileSystem();
+
+        PluginConfigurationSourceContext? capturedContext = null;
+        var configureSources = new List<Action<PluginConfigurationSourceContext>>
+        {
+            sourceContext => capturedContext = sourceContext,
+        };
+
+        // Act
+        using var context = new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources);
+
+        // Assert — the callback receives the same information the default plugin settings sources use.
+        Assert.NotNull(capturedContext);
+        Assert.NotNull(capturedContext.SettingsFileProvider);
+        Assert.Equal("settings.json", capturedContext.SettingsFileName);
+        Assert.Equal("Environment", capturedContext.EnvironmentName);
+        Assert.NotNull(capturedContext.OnLoadException);
+    }
+
+    [Fact]
+    public void BuildPluginConfiguration_PassesNullSettingsFileProviderAndFileName_WhenNoPluginSettingsFilePath()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<PluginSystemHostContext>>();
+        var environment = Substitute.For<IPluginSystemHostEnvironment>();
+        environment.EnvironmentName.Returns("Environment");
+        var hostConfiguration = Substitute.For<IConfigurationManager>();
+        var options = new PluginSystemOptions { PluginSettingsFilePath = string.Empty };
+        var fileSystem = new RealFileSystem();
+
+        PluginConfigurationSourceContext? capturedContext = null;
+        var configureSources = new List<Action<PluginConfigurationSourceContext>>
+        {
+            sourceContext => capturedContext = sourceContext,
+        };
+
+        // Act
+        using var context = new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources);
+
+        // Assert
+        Assert.NotNull(capturedContext);
+        Assert.Null(capturedContext.SettingsFileProvider);
+        Assert.Null(capturedContext.SettingsFileName);
+        Assert.Equal("Environment", capturedContext.EnvironmentName);
+    }
+
+    [Fact]
+    public void BuildPluginConfiguration_ContextOnLoadException_IgnoresAndLogsWarning_WhenAssignedToCustomSource()
+    {
+        // Arrange — verifies the escape hatch documented on PluginConfigurationSourceContext.OnLoadException:
+        // assigning the shared handler to a custom source gets the same ignore-and-log behavior as the
+        // default plugin settings sources.
+        var logger = Substitute.For<ILogger<PluginSystemHostContext>>();
+        var environment = Substitute.For<IPluginSystemHostEnvironment>();
+        var hostConfiguration = Substitute.For<IConfigurationManager>();
+        var options = new PluginSystemOptions { PluginSettingsFilePath = string.Empty };
+        var fileSystem = new RealFileSystem();
+
+        FileConfigurationSource? capturedSource = null;
+        var configureSources = new List<Action<PluginConfigurationSourceContext>>
+        {
+            sourceContext =>
+            {
+                sourceContext.Builder.AddJsonFile("nonexistent-explicit.json", optional: true, reloadOnChange: false);
+                capturedSource = (FileConfigurationSource)sourceContext.Builder.Sources[^1];
+                capturedSource.OnLoadException = sourceContext.OnLoadException;
+            },
+        };
+
+        // Act
+        using var context = new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources);
+
+        // Assert
+        Assert.NotNull(capturedSource);
+        var exceptionContext = new FileLoadExceptionContext { Exception = new InvalidDataException("malformed json") };
+        capturedSource.OnLoadException!(exceptionContext);
+
+        Assert.True(exceptionContext.Ignore);
+        logger.Received().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
     public void BuildPluginConfiguration_ShouldApplyCustomConfigurationSources()
     {
         // Arrange
@@ -163,10 +259,10 @@ public class PluginSystemHostContextTests
         var environment = Substitute.For<IPluginSystemHostEnvironment>();
         var hostConfiguration = Substitute.For<IConfigurationManager>();
         var options = new PluginSystemOptions { PluginSettingsFilePath = string.Empty };
-        var configureSources = new List<Action<IConfigurationBuilder>>
+        var configureSources = new List<Action<PluginConfigurationSourceContext>>
         {
-            builder =>
-            builder.AddInMemoryCollection(new Dictionary<string, string?>
+            sourceContext =>
+            sourceContext.Builder.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["Custom:Key"] = "CustomValue",
             }),
@@ -191,10 +287,10 @@ public class PluginSystemHostContextTests
         environment.PluginSettingsRootPath.Returns("./test-plugin-configs");
         var hostConfiguration = Substitute.For<IConfigurationManager>();
         var options = new PluginSystemOptions { PluginSettingsFilePath = "settings.json" };
-        var configureSources = new List<Action<IConfigurationBuilder>>
+        var configureSources = new List<Action<PluginConfigurationSourceContext>>
         {
-            builder =>
-            builder.AddInMemoryCollection(new Dictionary<string, string?>
+            sourceContext =>
+            sourceContext.Builder.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["Key"] = "OverriddenByCustomSource",
             }),
@@ -220,12 +316,12 @@ public class PluginSystemHostContextTests
         var fileSystem = new RealFileSystem();
 
         FileConfigurationSource? capturedSource = null;
-        var configureSources = new List<Action<IConfigurationBuilder>>
+        var configureSources = new List<Action<PluginConfigurationSourceContext>>
         {
-            builder =>
+            sourceContext =>
             {
-                builder.AddJsonFile("nonexistent-custom.json", optional: true, reloadOnChange: false);
-                capturedSource = (FileConfigurationSource)builder.Sources[^1];
+                sourceContext.Builder.AddJsonFile("nonexistent-custom.json", optional: true, reloadOnChange: false);
+                capturedSource = (FileConfigurationSource)sourceContext.Builder.Sources[^1];
             },
         };
 
@@ -274,12 +370,12 @@ public class PluginSystemHostContextTests
         Action<FileLoadExceptionContext> customHandler = _ => customHandlerInvoked = true;
 
         FileConfigurationSource? capturedSource = null;
-        var configureSources = new List<Action<IConfigurationBuilder>>
+        var configureSources = new List<Action<PluginConfigurationSourceContext>>
         {
-            builder =>
+            sourceContext =>
             {
-                builder.AddJsonFile("nonexistent-custom.json", optional: true, reloadOnChange: false);
-                capturedSource = (FileConfigurationSource)builder.Sources[^1];
+                sourceContext.Builder.AddJsonFile("nonexistent-custom.json", optional: true, reloadOnChange: false);
+                capturedSource = (FileConfigurationSource)sourceContext.Builder.Sources[^1];
                 capturedSource.OnLoadException = customHandler;
             },
         };
@@ -310,9 +406,9 @@ public class PluginSystemHostContextTests
         {
             fileSystem.File.WriteAllText(malformedJsonPath, "{ this is not valid json");
 
-            var configureSources = new List<Action<IConfigurationBuilder>>
+            var configureSources = new List<Action<PluginConfigurationSourceContext>>
             {
-                builder => builder.AddJsonFile(malformedJsonPath, optional: true, reloadOnChange: false),
+                sourceContext => sourceContext.Builder.AddJsonFile(malformedJsonPath, optional: true, reloadOnChange: false),
             };
 
             // Act & Assert — a malformed custom JSON file must not crash the host context construction.
@@ -343,14 +439,14 @@ public class PluginSystemHostContextTests
 
         var customHandlerCallCount = 0;
 
-        var configureSources = new List<Action<IConfigurationBuilder>>
+        var configureSources = new List<Action<PluginConfigurationSourceContext>>
         {
-            builder =>
+            sourceContext =>
             {
-                builder.AddJsonFile("nonexistent-index-test.json", optional: true, reloadOnChange: false);
+                sourceContext.Builder.AddJsonFile("nonexistent-index-test.json", optional: true, reloadOnChange: false);
 
                 // Index-based access: the source that was just added is the last one in the builder's source list.
-                var source = (FileConfigurationSource)builder.Sources[^1];
+                var source = (FileConfigurationSource)sourceContext.Builder.Sources[^1];
                 source.OnLoadException = ctx =>
                 {
                     ctx.Ignore = true;
@@ -388,7 +484,7 @@ public class PluginSystemHostContextTests
         var fileSystem = new RealFileSystem();
 
         var expectedException = new InvalidOperationException("custom callback failure");
-        var configureSources = new List<Action<IConfigurationBuilder>>
+        var configureSources = new List<Action<PluginConfigurationSourceContext>>
         {
             _ => throw expectedException,
         };
@@ -417,9 +513,9 @@ public class PluginSystemHostContextTests
         var throwingSource = Substitute.For<IConfigurationSource>();
         throwingSource.Build(Arg.Any<IConfigurationBuilder>()).Returns(_ => throw expectedException);
 
-        var configureSources = new List<Action<IConfigurationBuilder>>
+        var configureSources = new List<Action<PluginConfigurationSourceContext>>
         {
-            builder => builder.Add(throwingSource),
+            sourceContext => sourceContext.Builder.Add(throwingSource),
         };
 
         // Act & Assert — the original exception must propagate; it must not be wrapped or swallowed.
@@ -449,10 +545,10 @@ public class PluginSystemHostContextTests
         var options = new PluginSystemOptions { PluginSettingsFilePath = string.Empty };
         var fileSystem = new RealFileSystem();
 
-        var configureSources = new List<Action<IConfigurationBuilder>>
+        var configureSources = new List<Action<PluginConfigurationSourceContext>>
         {
-            builder => builder.AddJsonFile("nonexistent-a.json", optional: true, reloadOnChange: true),
-            builder => builder.AddJsonFile("nonexistent-b.json", optional: true, reloadOnChange: true),
+            sourceContext => sourceContext.Builder.AddJsonFile("nonexistent-a.json", optional: true, reloadOnChange: true),
+            sourceContext => sourceContext.Builder.AddJsonFile("nonexistent-b.json", optional: true, reloadOnChange: true),
         };
 
         // Act

--- a/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostContextTests.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostContextTests.cs
@@ -371,4 +371,60 @@ public class PluginSystemHostContextTests
         customSource.Source.OnLoadException(new FileLoadExceptionContext { Exception = new InvalidDataException() });
         Assert.Equal(1, customHandlerCallCount);
     }
+
+    [Fact]
+    public void BuildPluginConfiguration_CustomCallbackThrows_ExceptionPropagatesAndDoesNotLeakSettingsFileProvider()
+    {
+        // Arrange
+        // A settings file path is required so that a PhysicalFileProvider (and its FileSystemWatcher) is
+        // constructed before the custom callbacks run. If the catch block did not dispose it on throw, the
+        // watcher handle would leak until process exit.
+        var logger = Substitute.For<ILogger<PluginSystemHostContext>>();
+        var environment = Substitute.For<IPluginSystemHostEnvironment>();
+        environment.PluginSettingsRootPath.Returns("./test-plugin-configs");
+        var hostConfiguration = Substitute.For<IConfigurationManager>();
+        var options = new PluginSystemOptions { PluginSettingsFilePath = "settings.json" };
+        var fileSystem = new RealFileSystem();
+
+        var expectedException = new InvalidOperationException("custom callback failure");
+        var configureSources = new List<Action<IConfigurationBuilder>>
+        {
+            _ => throw expectedException,
+        };
+
+        // Act & Assert — the original exception must propagate; it must not be wrapped or swallowed.
+        var thrownException = Assert.Throws<InvalidOperationException>(() =>
+            new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources));
+
+        Assert.Same(expectedException, thrownException);
+    }
+
+    [Fact]
+    public void BuildPluginConfiguration_CustomSourceBuildThrows_ExceptionPropagatesAndDoesNotLeakSettingsFileProvider()
+    {
+        // Arrange
+        // Same leak scenario as above but the throw originates inside ConfigurationBuilder.Build() when
+        // a custom IConfigurationSource.Build() throws, not from the registration callback itself.
+        var logger = Substitute.For<ILogger<PluginSystemHostContext>>();
+        var environment = Substitute.For<IPluginSystemHostEnvironment>();
+        environment.PluginSettingsRootPath.Returns("./test-plugin-configs");
+        var hostConfiguration = Substitute.For<IConfigurationManager>();
+        var options = new PluginSystemOptions { PluginSettingsFilePath = "settings.json" };
+        var fileSystem = new RealFileSystem();
+
+        var expectedException = new InvalidOperationException("source build failure");
+        var throwingSource = Substitute.For<IConfigurationSource>();
+        throwingSource.Build(Arg.Any<IConfigurationBuilder>()).Returns(_ => throw expectedException);
+
+        var configureSources = new List<Action<IConfigurationBuilder>>
+        {
+            builder => builder.Add(throwingSource),
+        };
+
+        // Act & Assert — the original exception must propagate; it must not be wrapped or swallowed.
+        var thrownException = Assert.Throws<InvalidOperationException>(() =>
+            new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources));
+
+        Assert.Same(expectedException, thrownException);
+    }
 }

--- a/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostContextTests.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting.Tests/PluginSystemHostContextTests.cs
@@ -207,4 +207,168 @@ public class PluginSystemHostContextTests
         // Assert
         Assert.Equal("OverriddenByCustomSource", context.PluginConfiguration["Key"]);
     }
+
+    [Fact]
+    public void BuildPluginConfiguration_CustomFileSource_WithoutOnLoadException_GetsDefaultGuardApplied()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<PluginSystemHostContext>>();
+        var environment = Substitute.For<IPluginSystemHostEnvironment>();
+        var hostConfiguration = Substitute.For<IConfigurationManager>();
+        var options = new PluginSystemOptions { PluginSettingsFilePath = string.Empty };
+        var fileSystem = new RealFileSystem();
+
+        FileConfigurationSource? capturedSource = null;
+        var configureSources = new List<Action<IConfigurationBuilder>>
+        {
+            builder =>
+            {
+                builder.AddJsonFile("nonexistent-custom.json", optional: true, reloadOnChange: false);
+                capturedSource = (FileConfigurationSource)builder.Sources[^1];
+            },
+        };
+
+        // Act
+        using var context = new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources);
+
+        // Assert — the default OnLoadException guard must have been attached because the callback did not set one.
+        Assert.NotNull(capturedSource);
+        Assert.NotNull(capturedSource.OnLoadException);
+
+        // Verify the guard is also present on the provider that the built IConfigurationRoot actually uses,
+        // not only on the source object we captured in the callback. This guards against a future SDK change
+        // where ConfigurationBuilder.Build() snapshots/clones sources instead of referencing them directly.
+        var root = Assert.IsType<IConfigurationRoot>(context.PluginConfiguration, exactMatch: false);
+        var builtProvider = root.Providers
+            .OfType<FileConfigurationProvider>()
+            .Single(p => p.Source.Path == "nonexistent-custom.json");
+        Assert.NotNull(builtProvider.Source.OnLoadException);
+
+        var exceptionContext = new FileLoadExceptionContext
+        {
+            Exception = new InvalidDataException("malformed json"),
+        };
+        builtProvider.Source.OnLoadException!(exceptionContext);
+
+        Assert.True(exceptionContext.Ignore);
+        logger.Received().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public void BuildPluginConfiguration_CustomFileSource_WithExistingOnLoadException_IsNotOverwritten()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<PluginSystemHostContext>>();
+        var environment = Substitute.For<IPluginSystemHostEnvironment>();
+        var hostConfiguration = Substitute.For<IConfigurationManager>();
+        var options = new PluginSystemOptions { PluginSettingsFilePath = string.Empty };
+        var fileSystem = new RealFileSystem();
+
+        var customHandlerInvoked = false;
+        Action<FileLoadExceptionContext> customHandler = _ => customHandlerInvoked = true;
+
+        FileConfigurationSource? capturedSource = null;
+        var configureSources = new List<Action<IConfigurationBuilder>>
+        {
+            builder =>
+            {
+                builder.AddJsonFile("nonexistent-custom.json", optional: true, reloadOnChange: false);
+                capturedSource = (FileConfigurationSource)builder.Sources[^1];
+                capturedSource.OnLoadException = customHandler;
+            },
+        };
+
+        // Act
+        using var context = new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources);
+
+        // Assert — the custom handler must not have been replaced by the default guard.
+        Assert.NotNull(capturedSource);
+        Assert.Same(customHandler, capturedSource.OnLoadException);
+
+        capturedSource.OnLoadException!(new FileLoadExceptionContext { Exception = new InvalidDataException() });
+        Assert.True(customHandlerInvoked);
+    }
+
+    [Fact]
+    public void BuildPluginConfiguration_CustomFileSource_MalformedJson_DoesNotThrowDuringBuild()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<PluginSystemHostContext>>();
+        var environment = Substitute.For<IPluginSystemHostEnvironment>();
+        var hostConfiguration = Substitute.For<IConfigurationManager>();
+        var options = new PluginSystemOptions { PluginSettingsFilePath = string.Empty };
+        var fileSystem = new RealFileSystem();
+
+        var malformedJsonPath = fileSystem.Path.Combine(fileSystem.Path.GetTempPath(), $"{Guid.NewGuid()}.json");
+        try
+        {
+            fileSystem.File.WriteAllText(malformedJsonPath, "{ this is not valid json");
+
+            var configureSources = new List<Action<IConfigurationBuilder>>
+            {
+                builder => builder.AddJsonFile(malformedJsonPath, optional: true, reloadOnChange: false),
+            };
+
+            // Act & Assert — a malformed custom JSON file must not crash the host context construction.
+            var exception = Record.Exception(() =>
+            {
+                using var context = new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources);
+            });
+            Assert.Null(exception);
+        }
+        finally
+        {
+            fileSystem.File.Delete(malformedJsonPath);
+        }
+    }
+
+    [Fact]
+    public void BuildPluginConfiguration_CustomFileSource_IndexBasedOnLoadExceptionOverwrite_IsPreservedAndNotReplacedByDefaultGuard()
+    {
+        // Arrange
+        // This test documents the supported escape-hatch: a caller that needs full control over exception
+        // behaviour can set OnLoadException on the source by index *inside the callback*, and the default
+        // guard will not overwrite it afterwards.
+        var logger = Substitute.For<ILogger<PluginSystemHostContext>>();
+        var environment = Substitute.For<IPluginSystemHostEnvironment>();
+        var hostConfiguration = Substitute.For<IConfigurationManager>();
+        var options = new PluginSystemOptions { PluginSettingsFilePath = string.Empty };
+        var fileSystem = new RealFileSystem();
+
+        var customHandlerCallCount = 0;
+
+        var configureSources = new List<Action<IConfigurationBuilder>>
+        {
+            builder =>
+            {
+                builder.AddJsonFile("nonexistent-index-test.json", optional: true, reloadOnChange: false);
+
+                // Index-based access: the source that was just added is the last one in the builder's source list.
+                var source = (FileConfigurationSource)builder.Sources[^1];
+                source.OnLoadException = ctx =>
+                {
+                    ctx.Ignore = true;
+                    customHandlerCallCount++;
+                };
+            },
+        };
+
+        // Act
+        using var context = new PluginSystemHostContext(logger, environment, hostConfiguration, options, fileSystem, configureSources);
+
+        // Assert — the custom handler set via index access must be intact and be the one that fires.
+        var root = Assert.IsType<IConfigurationRoot>(context.PluginConfiguration, exactMatch: false);
+        var customSource = root.Providers
+            .OfType<FileConfigurationProvider>()
+            .Single(p => p.Source.Path == "nonexistent-index-test.json");
+
+        Assert.NotNull(customSource.Source.OnLoadException);
+        customSource.Source.OnLoadException(new FileLoadExceptionContext { Exception = new InvalidDataException() });
+        Assert.Equal(1, customHandlerCallCount);
+    }
 }

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/HostApplicationBuilderExtensions.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/HostApplicationBuilderExtensions.cs
@@ -36,8 +36,7 @@ public static class HostApplicationBuilderExtensions
             var environment = sp.GetRequiredService<IPluginSystemHostEnvironment>();
             var logger = sp.GetRequiredService<ILogger<PluginSystemHostContext>>();
             var fileSystem = sp.GetRequiredService<IFileSystem>();
-            var configurationSourcesOptions = sp.GetService<IOptions<PluginConfigurationSourcesOptions>>();
-            var configureSources = configurationSourcesOptions?.Value.ConfigureSources;
+            var configureSources = sp.GetRequiredService<IOptions<PluginConfigurationSourcesOptions>>().Value.ConfigureSources;
             return new PluginSystemHostContext(logger, environment, hostAppBuilder.Configuration, options.Value, fileSystem, configureSources);
         });
 

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/HostApplicationBuilderExtensions.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/HostApplicationBuilderExtensions.cs
@@ -36,7 +36,9 @@ public static class HostApplicationBuilderExtensions
             var environment = sp.GetRequiredService<IPluginSystemHostEnvironment>();
             var logger = sp.GetRequiredService<ILogger<PluginSystemHostContext>>();
             var fileSystem = sp.GetRequiredService<IFileSystem>();
-            return new PluginSystemHostContext(logger, environment, hostAppBuilder.Configuration, options.Value, fileSystem);
+            var configurationSourcesOptions = sp.GetService<IOptions<PluginConfigurationSourcesOptions>>();
+            var configureSources = configurationSourcesOptions?.Value.ConfigureSources;
+            return new PluginSystemHostContext(logger, environment, hostAppBuilder.Configuration, options.Value, fileSystem, configureSources);
         });
 
         pluginHostBuilder.Services.AddSingleton<IPublicServiceTypeRegistry, PublicServiceTypeRegistry>();

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/PluginConfigurationSourceContext.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/PluginConfigurationSourceContext.cs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2017-2026 TRUMPF Laser SE
+//
+// SPDX-License-Identifier: MPL-2.0
+
+namespace SAF.PluginSystem.Hosting;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+
+/// <summary>
+/// Provides a custom plugin configuration source callback with everything the built-in plugin settings
+/// pipeline already knows, so the callback can add sources that follow the same conventions (settings
+/// directory, environment overlay naming, load-exception handling) without re-deriving them.
+/// </summary>
+public sealed class PluginConfigurationSourceContext
+{
+    /// <summary>
+    /// The configuration builder the callback should append its providers to.
+    /// </summary>
+    public required IConfigurationBuilder Builder { get; init; }
+
+    /// <summary>
+    /// The <see cref="IFileProvider"/> scoped to the resolved plugin settings directory, i.e. the same
+    /// provider the default plugin settings JSON file(s) are loaded through. <see langword="null"/> if
+    /// <see cref="PluginSystemOptions.PluginSettingsFilePath"/> is not configured.
+    /// </summary>
+    public required IFileProvider? SettingsFileProvider { get; init; }
+
+    /// <summary>
+    /// The host environment name (e.g. "Development", "Production").
+    /// </summary>
+    public required string EnvironmentName { get; init; }
+
+    /// <summary>
+    /// The file name (without directory) of the default plugin settings file, e.g. "pluginsettings.json".
+    /// <see langword="null"/> if <see cref="PluginSystemOptions.PluginSettingsFilePath"/> is not configured.
+    /// </summary>
+    public required string? SettingsFileName { get; init; }
+
+    /// <summary>
+    /// The shared load-exception handler the default plugin settings sources use: it ignores the failure
+    /// and logs a warning so a malformed or half-written file neither crashes host startup nor silently
+    /// wipes values on reload. Assign it to a custom <see cref="FileConfigurationSource.OnLoadException"/>
+    /// to get the same behavior.
+    /// </summary>
+    public required Action<FileLoadExceptionContext> OnLoadException { get; init; }
+}

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/PluginConfigurationSourcesOptions.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/PluginConfigurationSourcesOptions.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2017-2026 TRUMPF Laser SE
+//
+// SPDX-License-Identifier: MPL-2.0
+
+namespace SAF.PluginSystem.Hosting;
+
+using Microsoft.Extensions.Configuration;
+
+internal sealed class PluginConfigurationSourcesOptions
+{
+    public IList<Action<IConfigurationBuilder>> ConfigureSources { get; } = [];
+}

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/PluginConfigurationSourcesOptions.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/PluginConfigurationSourcesOptions.cs
@@ -4,9 +4,7 @@
 
 namespace SAF.PluginSystem.Hosting;
 
-using Microsoft.Extensions.Configuration;
-
 internal sealed class PluginConfigurationSourcesOptions
 {
-    public IList<Action<IConfigurationBuilder>> ConfigureSources { get; } = [];
+    public IList<Action<PluginConfigurationSourceContext>> ConfigureSources { get; } = [];
 }

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostBuilderExtensions.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostBuilderExtensions.cs
@@ -5,7 +5,6 @@
 namespace SAF.PluginSystem.Hosting;
 
 using Contracts;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -17,11 +16,19 @@ public static class PluginSystemHostBuilderExtensions
     /// Appends a custom plugin configuration source to the plugin configuration builder pipeline.
     /// </summary>
     /// <param name="hostBuilder">The plugin system host builder.</param>
-    /// <param name="configureSource">The callback that appends one or more providers to the plugin configuration builder.</param>
+    /// <param name="configureSource">
+    /// The callback that appends one or more providers to the plugin configuration builder. It receives a
+    /// <see cref="PluginConfigurationSourceContext"/> giving access to the resolved plugin settings file
+    /// provider, environment name, settings file name, and the shared load-exception handler, so sources
+    /// that follow the same conventions as the built-in plugin settings file (e.g. an environment-specific
+    /// overlay with a different extension) can be expressed in a single call.
+    /// The callback runs exactly once, during <see cref="IPluginSystemHostContext"/> construction; any
+    /// exception it throws propagates into host startup.
+    /// </param>
     /// <returns>The same <see cref="IPluginSystemHostBuilder"/> instance for chaining.</returns>
     public static IPluginSystemHostBuilder AddPluginConfigurationSource(
         this IPluginSystemHostBuilder hostBuilder,
-        Action<IConfigurationBuilder> configureSource)
+        Action<PluginConfigurationSourceContext> configureSource)
     {
         ArgumentNullException.ThrowIfNull(hostBuilder);
         ArgumentNullException.ThrowIfNull(configureSource);
@@ -32,6 +39,12 @@ public static class PluginSystemHostBuilderExtensions
         return hostBuilder;
     }
 
+    /// <summary>
+    /// Registers a plugin assembly container that discovers plugin assemblies by scanning a folder, using
+    /// the default <see cref="PluginAssemblyFolderSearchOptions"/>.
+    /// </summary>
+    /// <param name="hostBuilder">The plugin system host builder.</param>
+    /// <returns>The same <see cref="IPluginSystemHostBuilder"/> instance for chaining.</returns>
     public static IPluginSystemHostBuilder AddPluginAssemblyFolderContainer(this IPluginSystemHostBuilder hostBuilder)
     {
         ArgumentNullException.ThrowIfNull(hostBuilder);
@@ -39,6 +52,12 @@ public static class PluginSystemHostBuilderExtensions
         return hostBuilder.AddPluginAssemblyFolderContainer(_ => { });
     }
 
+    /// <summary>
+    /// Registers a plugin assembly container that discovers plugin assemblies by scanning a folder.
+    /// </summary>
+    /// <param name="hostBuilder">The plugin system host builder.</param>
+    /// <param name="configureSearch">The callback that configures the folder search (root path, recursion, include/exclude patterns).</param>
+    /// <returns>The same <see cref="IPluginSystemHostBuilder"/> instance for chaining.</returns>
     public static IPluginSystemHostBuilder AddPluginAssemblyFolderContainer(this IPluginSystemHostBuilder hostBuilder, Action<PluginAssemblyFolderSearchOptions> configureSearch)
     {
         ArgumentNullException.ThrowIfNull(hostBuilder);

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostBuilderExtensions.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostBuilderExtensions.cs
@@ -5,6 +5,7 @@
 namespace SAF.PluginSystem.Hosting;
 
 using Contracts;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -12,6 +13,25 @@ using System.IO.Abstractions;
 
 public static class PluginSystemHostBuilderExtensions
 {
+    /// <summary>
+    /// Appends a custom plugin configuration source to the plugin configuration builder pipeline.
+    /// </summary>
+    /// <param name="hostBuilder">The plugin system host builder.</param>
+    /// <param name="configureSource">The callback that appends one or more providers to the plugin configuration builder.</param>
+    /// <returns>The same <see cref="IPluginSystemHostBuilder"/> instance for chaining.</returns>
+    public static IPluginSystemHostBuilder AddPluginConfigurationSource(
+        this IPluginSystemHostBuilder hostBuilder,
+        Action<IConfigurationBuilder> configureSource)
+    {
+        ArgumentNullException.ThrowIfNull(hostBuilder);
+        ArgumentNullException.ThrowIfNull(configureSource);
+
+        hostBuilder.Services.Configure<PluginConfigurationSourcesOptions>(options =>
+            options.ConfigureSources.Add(configureSource));
+
+        return hostBuilder;
+    }
+
     public static IPluginSystemHostBuilder AddPluginAssemblyFolderContainer(this IPluginSystemHostBuilder hostBuilder)
     {
         ArgumentNullException.ThrowIfNull(hostBuilder);

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
@@ -55,7 +55,7 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         var builder = new ConfigurationBuilder();
 
         var settingsFileProvider = AddDefaultPluginConfigurationSources(builder, logger, options, environment, fileSystem);
-        AddCustomPluginConfigurationSources(builder, configurePluginConfigurationSources);
+        AddCustomPluginConfigurationSources(builder, logger, configurePluginConfigurationSources);
 
         return (builder.Build(), settingsFileProvider);
     }
@@ -104,12 +104,32 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
     }
 
     private static void AddCustomPluginConfigurationSources(
-      IConfigurationBuilder builder,
-      IEnumerable<Action<IConfigurationBuilder>> configurePluginConfigurationSources)
+        ConfigurationBuilder builder,
+        ILogger logger,
+        IEnumerable<Action<IConfigurationBuilder>> configurePluginConfigurationSources)
     {
+        var countBefore = builder.Sources.Count;
+
         foreach (var configureSource in configurePluginConfigurationSources)
         {
             configureSource(builder);
+        }
+
+        // Apply the same OnLoadException guard that default sources receive to any FileConfigurationSource
+        // added by custom callbacks that does not already have one, so a malformed or half-written file
+        // neither crashes host startup nor silently wipes values on reload.
+        for (var i = countBefore; i < builder.Sources.Count; i++)
+        {
+            if (builder.Sources[i] is FileConfigurationSource { OnLoadException: null } fileSource)
+            {
+                fileSource.OnLoadException = context =>
+                {
+                    context.Ignore = true;
+                    logger.LogWarning(context.Exception,
+                        "Failed to load plugin configuration file {PluginSettingsFilePath}. A later successful reload will apply updated values.",
+                        fileSource.Path);
+                };
+            }
         }
     }
 

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
@@ -23,7 +23,7 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         IConfigurationManager hostConfiguration,
         PluginSystemOptions options,
         IFileSystem fileSystem,
-        IEnumerable<Action<IConfigurationBuilder>>? configurePluginConfigurationSources = null)
+        IEnumerable<Action<PluginConfigurationSourceContext>>? configurePluginConfigurationSources = null)
     {
         Environment = environment;
         HostConfiguration = hostConfiguration;
@@ -52,11 +52,12 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         PluginSystemOptions options,
         IPluginSystemHostEnvironment environment,
         IFileSystem fileSystem,
-        IEnumerable<Action<IConfigurationBuilder>> configurePluginConfigurationSources)
+        IEnumerable<Action<PluginConfigurationSourceContext>> configurePluginConfigurationSources)
     {
         var builder = new ConfigurationBuilder();
+        var onLoadException = CreateOnLoadExceptionHandler(logger);
 
-        var settingsFileProvider = AddDefaultPluginConfigurationSources(builder, logger, options, environment, fileSystem);
+        var (settingsFileProvider, settingsFileName) = AddDefaultPluginConfigurationSources(builder, logger, options, environment, fileSystem, onLoadException);
 
         // Seed a single shared PhysicalFileProvider as the builder's default so that every custom
         // FileConfigurationSource that does not set its own FileProvider reuses this one instance
@@ -68,7 +69,16 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
 
         try
         {
-            AddCustomPluginConfigurationSources(builder, logger, configurePluginConfigurationSources);
+            var sourceContext = new PluginConfigurationSourceContext
+            {
+                Builder = builder,
+                SettingsFileProvider = settingsFileProvider,
+                EnvironmentName = environment.EnvironmentName,
+                SettingsFileName = settingsFileName,
+                OnLoadException = onLoadException,
+            };
+
+            AddCustomPluginConfigurationSources(builder, sourceContext, configurePluginConfigurationSources, onLoadException);
             return (builder.Build(), settingsFileProvider, customSourcesDefaultFileProvider);
         }
         catch
@@ -81,19 +91,20 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         }
     }
 
-    private static PhysicalFileProvider? AddDefaultPluginConfigurationSources(
+    private static (PhysicalFileProvider? settingsFileProvider, string? settingsFileName) AddDefaultPluginConfigurationSources(
         IConfigurationBuilder builder,
         ILogger logger,
         PluginSystemOptions options,
         IPluginSystemHostEnvironment environment,
-        IFileSystem fileSystem)
+        IFileSystem fileSystem,
+        Action<FileLoadExceptionContext> onLoadException)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
         if (string.IsNullOrEmpty(options.PluginSettingsFilePath))
         {
             logger.LogInformation("No plugin configuration file configured.");
-            return null;
+            return (null, null);
         }
 
         var settingsFilePath = CreateAbsolutePath(fileSystem, AppContext.BaseDirectory, fileSystem.Path.Combine(environment.PluginSettingsRootPath, options.PluginSettingsFilePath));
@@ -116,24 +127,25 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
                 options.PluginSettingsFilePath, settingsFilePath);
         }
 
-        AddJsonFile(builder, logger, settingsFileProvider, settingsFileName);
+        AddJsonFile(builder, settingsFileProvider, settingsFileName, onLoadException);
 
         var environmentSettingsFileName = $"{fileSystem.Path.GetFileNameWithoutExtension(settingsFileName)}.{environment.EnvironmentName}{fileSystem.Path.GetExtension(settingsFileName)}";
-        AddJsonFile(builder, logger, settingsFileProvider, environmentSettingsFileName);
+        AddJsonFile(builder, settingsFileProvider, environmentSettingsFileName, onLoadException);
 
-        return settingsFileProvider;
+        return (settingsFileProvider, settingsFileName);
     }
 
     private static void AddCustomPluginConfigurationSources(
         ConfigurationBuilder builder,
-        ILogger logger,
-        IEnumerable<Action<IConfigurationBuilder>> configurePluginConfigurationSources)
+        PluginConfigurationSourceContext sourceContext,
+        IEnumerable<Action<PluginConfigurationSourceContext>> configurePluginConfigurationSources,
+        Action<FileLoadExceptionContext> onLoadException)
     {
         var countBefore = builder.Sources.Count;
 
         foreach (var configureSource in configurePluginConfigurationSources)
         {
-            configureSource(builder);
+            configureSource(sourceContext);
         }
 
         // Apply the same OnLoadException guard that default sources receive to any FileConfigurationSource
@@ -143,31 +155,27 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         {
             if (builder.Sources[i] is FileConfigurationSource { OnLoadException: null } fileSource)
             {
-                fileSource.OnLoadException = context =>
-                {
-                    context.Ignore = true;
-                    logger.LogWarning(context.Exception,
-                        "Failed to load plugin configuration file {PluginSettingsFilePath}. A later successful reload will apply updated values.",
-                        fileSource.Path);
-                };
+                fileSource.OnLoadException = onLoadException;
             }
         }
     }
 
-    private static void AddJsonFile(IConfigurationBuilder builder, ILogger logger, PhysicalFileProvider settingsFileProvider, string settingsFileName)
+    private static Action<FileLoadExceptionContext> CreateOnLoadExceptionHandler(ILogger logger) => exceptionContext =>
+    {
+        exceptionContext.Ignore = true;
+        logger.LogWarning(exceptionContext.Exception,
+            "Failed to load plugin configuration file {PluginSettingsFilePath}. A later successful reload will apply updated values.",
+            exceptionContext.Provider?.Source.Path);
+    };
+
+    private static void AddJsonFile(IConfigurationBuilder builder, PhysicalFileProvider settingsFileProvider, string settingsFileName, Action<FileLoadExceptionContext> onLoadException)
         => builder.AddJsonFile(source =>
         {
             source.FileProvider = settingsFileProvider;
             source.Path = settingsFileName;
             source.Optional = true;
             source.ReloadOnChange = true;
-            source.OnLoadException = context =>
-            {
-                context.Ignore = true;
-                logger.LogWarning(context.Exception,
-                    "Failed to load plugin configuration file {PluginSettingsFilePath}. A later successful reload will apply updated values.",
-                    settingsFileName);
-            };
+            source.OnLoadException = onLoadException;
         });
 
     private static string CreateAbsolutePath(IFileSystem fileSystem, string basePath, string path)

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
@@ -27,7 +27,8 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         Environment = environment;
         HostConfiguration = hostConfiguration;
 
-        (_pluginConfigurationRoot, _pluginSettingsFileProvider) = BuildPluginConfiguration(logger, options, environment, fileSystem, configurePluginConfigurationSources ?? []);
+        (_pluginConfigurationRoot, _pluginSettingsFileProvider) =
+            BuildPluginConfiguration(logger, options, environment, fileSystem, configurePluginConfigurationSources ?? []);
     }
 
     public IPluginSystemHostEnvironment Environment { get; }
@@ -44,7 +45,7 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         _pluginSettingsFileProvider?.Dispose();
     }
 
-    private static (IConfigurationRoot ConfigurationRoot, PhysicalFileProvider? SettingsFileProvider) BuildPluginConfiguration(
+    private static (IConfigurationRoot configurationRoot, PhysicalFileProvider? settingsFileProvider) BuildPluginConfiguration(
         ILogger logger,
         PluginSystemOptions options,
         IPluginSystemHostEnvironment environment,
@@ -53,10 +54,10 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
     {
         var builder = new ConfigurationBuilder();
 
-        AddDefaultPluginConfigurationSources(builder, logger, options, environment, fileSystem);
+        var settingsFileProvider = AddDefaultPluginConfigurationSources(builder, logger, options, environment, fileSystem);
         AddCustomPluginConfigurationSources(builder, configurePluginConfigurationSources);
 
-        return builder.Build();
+        return (builder.Build(), settingsFileProvider);
     }
 
     private static PhysicalFileProvider? AddDefaultPluginConfigurationSources(
@@ -115,7 +116,7 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         }
     }
 
-    private static void AddJsonFile(ConfigurationBuilder builder, ILogger logger, PhysicalFileProvider settingsFileProvider, string settingsFileName)
+    private static void AddJsonFile(IConfigurationBuilder builder, ILogger logger, PhysicalFileProvider settingsFileProvider, string settingsFileName)
         => builder.AddJsonFile(source =>
         {
             source.FileProvider = settingsFileProvider;

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
@@ -55,9 +55,19 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         var builder = new ConfigurationBuilder();
 
         var settingsFileProvider = AddDefaultPluginConfigurationSources(builder, logger, options, environment, fileSystem);
-        AddCustomPluginConfigurationSources(builder, logger, configurePluginConfigurationSources);
-
-        return (builder.Build(), settingsFileProvider);
+        try
+        {
+            AddCustomPluginConfigurationSources(builder, logger, configurePluginConfigurationSources);
+            return (builder.Build(), settingsFileProvider);
+        }
+        catch
+        {
+            // settingsFileProvider owns a PhysicalFilesWatcher / FileSystemWatcher handle. If anything
+            // between its construction and the successful return throws, the constructor will never assign
+            // _pluginSettingsFileProvider and Dispose() will never run, leaking the handle.
+            settingsFileProvider?.Dispose();
+            throw;
+        }
     }
 
     private static PhysicalFileProvider? AddDefaultPluginConfigurationSources(

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
@@ -102,14 +102,11 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
 
         return settingsFileProvider;
     }
-    
-    private static void AddCustomPluginConfigurationSources(
-        IConfigurationBuilder builder,
-        IEnumerable<Action<IConfigurationBuilder>> configurePluginConfigurationSources)
-    {
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(configurePluginConfigurationSources);
 
+    private static void AddCustomPluginConfigurationSources(
+      IConfigurationBuilder builder,
+      IEnumerable<Action<IConfigurationBuilder>> configurePluginConfigurationSources)
+    {
         foreach (var configureSource in configurePluginConfigurationSources)
         {
             configureSource(builder);

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
@@ -21,12 +21,13 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         IPluginSystemHostEnvironment environment,
         IConfigurationManager hostConfiguration,
         PluginSystemOptions options,
-        IFileSystem fileSystem)
+        IFileSystem fileSystem,
+        IEnumerable<Action<IConfigurationBuilder>>? configurePluginConfigurationSources = null)
     {
         Environment = environment;
         HostConfiguration = hostConfiguration;
 
-        (_pluginConfigurationRoot, _pluginSettingsFileProvider) = BuildPluginConfiguration(logger, options, environment, fileSystem);
+        (_pluginConfigurationRoot, _pluginSettingsFileProvider) = BuildPluginConfiguration(logger, options, environment, fileSystem, configurePluginConfigurationSources ?? []);
     }
 
     public IPluginSystemHostEnvironment Environment { get; }
@@ -47,14 +48,30 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         ILogger logger,
         PluginSystemOptions options,
         IPluginSystemHostEnvironment environment,
-        IFileSystem fileSystem)
+        IFileSystem fileSystem,
+        IEnumerable<Action<IConfigurationBuilder>> configurePluginConfigurationSources)
     {
         var builder = new ConfigurationBuilder();
+
+        AddDefaultPluginConfigurationSources(builder, logger, options, environment, fileSystem);
+        AddCustomPluginConfigurationSources(builder, configurePluginConfigurationSources);
+
+        return builder.Build();
+    }
+
+    private static PhysicalFileProvider? AddDefaultPluginConfigurationSources(
+        IConfigurationBuilder builder,
+        ILogger logger,
+        PluginSystemOptions options,
+        IPluginSystemHostEnvironment environment,
+        IFileSystem fileSystem)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
 
         if (string.IsNullOrEmpty(options.PluginSettingsFilePath))
         {
             logger.LogInformation("No plugin configuration file configured.");
-            return (builder.Build(), null);
+            return null;
         }
 
         var settingsFilePath = CreateAbsolutePath(fileSystem, AppContext.BaseDirectory, fileSystem.Path.Combine(environment.PluginSettingsRootPath, options.PluginSettingsFilePath));
@@ -82,7 +99,20 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         var environmentSettingsFileName = $"{fileSystem.Path.GetFileNameWithoutExtension(settingsFileName)}.{environment.EnvironmentName}{fileSystem.Path.GetExtension(settingsFileName)}";
         AddJsonFile(builder, logger, settingsFileProvider, environmentSettingsFileName);
 
-        return (builder.Build(), settingsFileProvider);
+        return settingsFileProvider;
+    }
+    
+    private static void AddCustomPluginConfigurationSources(
+        IConfigurationBuilder builder,
+        IEnumerable<Action<IConfigurationBuilder>> configurePluginConfigurationSources)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configurePluginConfigurationSources);
+
+        foreach (var configureSource in configurePluginConfigurationSources)
+        {
+            configureSource(builder);
+        }
     }
 
     private static void AddJsonFile(ConfigurationBuilder builder, ILogger logger, PhysicalFileProvider settingsFileProvider, string settingsFileName)

--- a/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
+++ b/src/PluginSystem/SAF.PluginSystem.Hosting/PluginSystemHostContext.cs
@@ -15,6 +15,7 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
 {
     private readonly IConfigurationRoot _pluginConfigurationRoot;
     private readonly PhysicalFileProvider? _pluginSettingsFileProvider;
+    private readonly PhysicalFileProvider _customSourcesDefaultFileProvider;
 
     public PluginSystemHostContext(
         ILogger<PluginSystemHostContext> logger,
@@ -27,7 +28,7 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         Environment = environment;
         HostConfiguration = hostConfiguration;
 
-        (_pluginConfigurationRoot, _pluginSettingsFileProvider) =
+        (_pluginConfigurationRoot, _pluginSettingsFileProvider, _customSourcesDefaultFileProvider) =
             BuildPluginConfiguration(logger, options, environment, fileSystem, configurePluginConfigurationSources ?? []);
     }
 
@@ -43,9 +44,10 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         }
 
         _pluginSettingsFileProvider?.Dispose();
+        _customSourcesDefaultFileProvider.Dispose();
     }
 
-    private static (IConfigurationRoot configurationRoot, PhysicalFileProvider? settingsFileProvider) BuildPluginConfiguration(
+    private static (IConfigurationRoot configurationRoot, PhysicalFileProvider? settingsFileProvider, PhysicalFileProvider customSourcesDefaultFileProvider) BuildPluginConfiguration(
         ILogger logger,
         PluginSystemOptions options,
         IPluginSystemHostEnvironment environment,
@@ -55,16 +57,25 @@ public sealed class PluginSystemHostContext : IPluginSystemHostContext, IDisposa
         var builder = new ConfigurationBuilder();
 
         var settingsFileProvider = AddDefaultPluginConfigurationSources(builder, logger, options, environment, fileSystem);
+
+        // Seed a single shared PhysicalFileProvider as the builder's default so that every custom
+        // FileConfigurationSource that does not set its own FileProvider reuses this one instance
+        // instead of having FileConfigurationSource.EnsureDefaults() create a new
+        // PhysicalFileProvider(AppContext.BaseDirectory) per source. All of those per-source providers
+        // would otherwise be undisposed, each holding a recursive FileSystemWatcher on the base directory.
+        var customSourcesDefaultFileProvider = new PhysicalFileProvider(AppContext.BaseDirectory);
+        builder.SetFileProvider(customSourcesDefaultFileProvider);
+
         try
         {
             AddCustomPluginConfigurationSources(builder, logger, configurePluginConfigurationSources);
-            return (builder.Build(), settingsFileProvider);
+            return (builder.Build(), settingsFileProvider, customSourcesDefaultFileProvider);
         }
         catch
         {
-            // settingsFileProvider owns a PhysicalFilesWatcher / FileSystemWatcher handle. If anything
-            // between its construction and the successful return throws, the constructor will never assign
-            // _pluginSettingsFileProvider and Dispose() will never run, leaking the handle.
+            // Both providers own FileSystemWatcher handles. Dispose them before the exception escapes
+            // so that the constructor failure does not leak handles until process exit.
+            customSourcesDefaultFileProvider.Dispose();
             settingsFileProvider?.Dispose();
             throw;
         }


### PR DESCRIPTION
Apply external configuration sources to the plugin settings.
This allows applications to provide settings from different sources and file formats as currently supported in SAF (which is the configured plugin-settings JSON).